### PR TITLE
Scanner considers single quote of attribute value

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/internal/parser/Constants.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/internal/parser/Constants.java
@@ -21,6 +21,7 @@ class Constants {
 	public final static int _EQS = "=".codePointAt(0);
 	public final static int _DQO = "\"".codePointAt(0);
 	public final static int _SQO = "\"".codePointAt(0);
+	public final static int _SIQ = "\'".codePointAt(0);
 	public final static int _NWL = "\n".codePointAt(0);
 	public final static int _CAR = "\r".codePointAt(0);
 	public final static int _LFD = "\f".codePointAt(0);

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/internal/parser/XMLScanner.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/internal/parser/XMLScanner.java
@@ -26,6 +26,7 @@ import static org.eclipse.lsp4xml.internal.parser.Constants._OSB;
 import static org.eclipse.lsp4xml.internal.parser.Constants._QMA;
 import static org.eclipse.lsp4xml.internal.parser.Constants._RAN;
 import static org.eclipse.lsp4xml.internal.parser.Constants._SQO;
+import static org.eclipse.lsp4xml.internal.parser.Constants._SIQ;
 import static org.eclipse.lsp4xml.internal.parser.Constants._TVL;
 import static org.eclipse.lsp4xml.internal.parser.Constants._XVL;
 
@@ -262,7 +263,7 @@ public class XMLScanner implements Scanner {
 				return finishToken(offset, TokenType.AttributeValue);
 			}
 			int ch = stream.peekChar();
-			if (ch == _SQO || ch == _DQO) {
+			if (ch == _SQO || ch == _DQO || ch == _SIQ) {
 				stream.advance(1); // consume quote
 				if (stream.advanceUntilChar(ch)) {
 					stream.advance(1); // consume quote

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/internal/parser/XMLScannerTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/internal/parser/XMLScannerTest.java
@@ -474,6 +474,18 @@ public class XMLScannerTest {
 		assertOffsetAndToken(14, TokenType.StartTagClose);
 	}
 
+	@Test
+	public void testAttributeSingleQuote() {
+		scanner = XMLScanner.createScanner("<abc foo=\'bar\'>");
+		assertOffsetAndToken(0, TokenType.StartTagOpen);
+		assertOffsetAndToken(1, TokenType.StartTag, "abc");
+		assertOffsetAndToken(4, TokenType.Whitespace);
+		assertOffsetAndToken(5, TokenType.AttributeName);
+		assertOffsetAndToken(8, TokenType.DelimiterAssign);
+		assertOffsetAndToken(9, TokenType.AttributeValue);
+		assertOffsetAndToken(14, TokenType.StartTagClose);
+	}
+
 
 	@Test
 	public void testName32() {


### PR DESCRIPTION
eg: `<tag key='value'></tag>`