### PR TITLE
Display server version on startup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
 	//Use consistent indentation
 	"editor.detectIndentation": false,
 	"editor.tabSize": 4,
-	"editor.insertSpaces": false
+	"editor.insertSpaces": false,
+	"java.configuration.updateBuildConfiguration": "interactive"
 }

--- a/org.eclipse.lsp4xml/pom.xml
+++ b/org.eclipse.lsp4xml/pom.xml
@@ -1,6 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.eclipse</groupId>
@@ -10,16 +8,47 @@
 	<artifactId>org.eclipse.lsp4xml</artifactId>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.build.timestamp.format>yyyyMMdd-HHmm</maven.build.timestamp.format>
+		<dev.build.timestamp>${maven.build.timestamp}</dev.build.timestamp>
 	</properties>
 	<build>
+		<resources>
+			<resource>
+				<directory>src/main/resources/</directory>
+				<filtering>true</filtering>
+				<includes>
+					<include>**/*.properties</include>
+				</includes>
+			</resource>
+			<resource>
+				<directory>src/main/resources/</directory>
+				<filtering>false</filtering>
+				<excludes>
+					<exclude>**/*.properties</exclude>
+				</excludes>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.7.0</version>
+				<version>3.8.0</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
 				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>3.0.0</version>
+				<executions>
+					<execution>
+						<id>parse-version</id>
+						<goals>
+							<goal>parse-version</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<artifactId>maven-assembly-plugin</artifactId>
@@ -93,17 +122,4 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-	<repositories>
-		<repository>
-			<id>lsp4j-snapshot</id>
-			<layout>default</layout>
-			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-			<releases>
-				<enabled>false</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
 </project>

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLLanguageServer.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLLanguageServer.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4xml;
 
 import static org.eclipse.lsp4j.jsonrpc.CompletableFutures.computeAsync;
+import static org.eclipse.lsp4xml.utils.VersionHelper.getVersion;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
@@ -67,7 +68,7 @@ public class XMLLanguageServer implements LanguageServer, ProcessLanguageServer,
 
 	@Override
 	public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
-		LOGGER.info("Initializing LSP4XML server");
+		LOGGER.info("Initializing LSP4XML server " + getVersion());
 		this.parentProcessId = params.getProcessId();
 
 		capabilityManager.setClientCapabilities(params.getCapabilities());

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/logs/LogHelper.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/logs/LogHelper.java
@@ -37,7 +37,7 @@ public class LogHelper {
 
 		Logger logger = Logger.getLogger("");
 		unregisterAllHandlers(logger.getHandlers());
-		logger.setLevel(Level.SEVERE);
+		logger.setLevel(Level.INFO);
 		logger.setUseParentHandlers(false);// Stops output to console
 
 		// Configure logging LSP client handler
@@ -68,11 +68,11 @@ public class LogHelper {
 
 	private static void createDirectoryPath(String path) {
 		Path parentPath = Paths.get(path).normalize().getParent();
-		if(parentPath != null) {
+		if (parentPath != null) {
 			try {
 				Files.createDirectories(parentPath);
 			} catch (IOException e) {
-				
+
 			}
 		}
 	}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/VersionHelper.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/VersionHelper.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright (c) 2018 Red Hat, Inc.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Fred Bricon <fbricon@gmail.com>, Red Hat Inc. - initial API and implementation
+ */
+package org.eclipse.lsp4xml.utils;
+
+import java.util.ResourceBundle;
+
+/**
+ * Helper object to retrieve the current version of the server.
+ */
+public class VersionHelper {
+
+	private VersionHelper() {
+		// No instantiation
+	}
+
+	/**
+	 * Returns the version of the server with the format
+	 * <code>major.minor.incremental-timestamp</code>.
+	 * 
+	 * @return the server version
+	 */
+	public static String getVersion() {
+		// No need to make it a static field as it'll be used only once
+		ResourceBundle bundle = ResourceBundle.getBundle("version");
+		String version = bundle.getString("version");
+		return version;
+	}
+}

--- a/org.eclipse.lsp4xml/src/main/resources/version.properties
+++ b/org.eclipse.lsp4xml/src/main/resources/version.properties
@@ -1,0 +1,1 @@
+version=${parsedVersion.majorVersion}.${parsedVersion.minorVersion}.${parsedVersion.incrementalVersion}-${dev.build.timestamp}

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/utils/VersionHelperTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/utils/VersionHelperTest.java
@@ -1,0 +1,29 @@
+/**
+ *  Copyright (c) 2018 Red Hat, Inc.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Fred Bricon <fbricon@gmail.com>, Red Hat Inc. - initial API and implementation
+ */
+package org.eclipse.lsp4xml.utils;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+public class VersionHelperTest {
+
+	@Test
+	public void testGetVersion() {
+		String version = VersionHelper.getVersion();
+		Pattern pattern = Pattern.compile("^(\\d+\\.\\d+\\.\\d+)(-.*)$");
+		Matcher matcher = pattern.matcher(version);
+		assertTrue("Unexpected format for :" + version, matcher.matches());
+	}
+}


### PR DESCRIPTION
helps check which version of the server is running. This is done by enabling 
Maven's resource filtering and lowering the logging threshold to INFO.