### PR TITLE
The setting 'completions.autoCloseTags' is used to determine if an end tag is a part of the text edit

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLLanguageServer.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLLanguageServer.java
@@ -35,6 +35,7 @@ import org.eclipse.lsp4xml.commons.TextDocument;
 import org.eclipse.lsp4xml.dom.XMLDocument;
 import org.eclipse.lsp4xml.logs.LogHelper;
 import org.eclipse.lsp4xml.services.XMLLanguageService;
+import org.eclipse.lsp4xml.services.extensions.CompletionSettings;
 import org.eclipse.lsp4xml.settings.InitializationOptionsSettings;
 import org.eclipse.lsp4xml.settings.LogsSettings;
 import org.eclipse.lsp4xml.settings.XMLClientSettings;
@@ -121,6 +122,12 @@ public class XMLLanguageServer implements LanguageServer, ProcessLanguageServer,
 			if (formatterSettings != null) {
 				xmlTextDocumentService.setSharedFormattingOptions(formatterSettings);
 			}
+
+			CompletionSettings newCompletions = clientSettings.getCompletion();
+			if (newCompletions != null) {
+				xmlTextDocumentService.updateCompletionSettings(newCompletions);
+			}
+			
 			// Experimental capabilities
 			XMLExperimentalCapabilities experimental = clientSettings.getExperimental();
 			if (experimental != null) {

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLTextDocumentService.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLTextDocumentService.java
@@ -117,10 +117,14 @@ public class XMLTextDocumentService implements TextDocumentService {
 		TextDocumentClientCapabilities textDocumentClientCapabilities = capabilities.getTextDocument();
 		if (textDocumentClientCapabilities != null) {
 			// Completion settings
-			sharedCompletionSettings.update(textDocumentClientCapabilities.getCompletion());
+			sharedCompletionSettings.setCapabilities(textDocumentClientCapabilities.getCompletion());
 			codeActionLiteralSupport = textDocumentClientCapabilities.getCodeAction() != null
 					&& textDocumentClientCapabilities.getCodeAction().getCodeActionLiteralSupport() != null;
 		}
+	}
+
+	public void updateCompletionSettings(CompletionSettings newCompletion) {
+		sharedCompletionSettings.setAutoCloseTags(newCompletion.isAutoCloseTags());
 	}
 
 	public TextDocument getDocument(String uri) {

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/contentmodel/utils/XMLGenerator.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/contentmodel/utils/XMLGenerator.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.eclipse.lsp4xml.contentmodel.model.CMAttributeDeclaration;
 import org.eclipse.lsp4xml.contentmodel.model.CMElementDeclaration;
+import org.eclipse.lsp4xml.services.extensions.CompletionSettings;
 import org.eclipse.lsp4xml.settings.XMLFormattingOptions;
 import org.eclipse.lsp4xml.utils.XMLBuilder;
 
@@ -29,6 +30,7 @@ public class XMLGenerator {
 	private final String whitespacesIndent;
 	private final String lineDelimiter;
 	private final boolean canSupportSnippets;
+	private final boolean autoCloseTags;
 	private int maxLevel;
 
 	/**
@@ -45,7 +47,13 @@ public class XMLGenerator {
 	 */
 	public XMLGenerator(XMLFormattingOptions formattingOptions, String whitespacesIndent, String lineDelimiter,
 			boolean canSupportSnippets, int maxLevel) {
+		this(formattingOptions, true, whitespacesIndent, lineDelimiter, canSupportSnippets, maxLevel);
+	}
+
+	public XMLGenerator(XMLFormattingOptions formattingOptions, boolean autoCloseTags, String whitespacesIndent, 
+			String lineDelimiter, boolean canSupportSnippets, int maxLevel) {
 		this.formattingOptions = formattingOptions;
+		this.autoCloseTags = autoCloseTags;
 		this.whitespacesIndent = whitespacesIndent;
 		this.lineDelimiter = lineDelimiter;
 		this.canSupportSnippets = canSupportSnippets;
@@ -100,8 +108,10 @@ public class XMLGenerator {
 					xml.addContent("$" + snippetIndex);
 				}
 			}
-			xml.endElement(prefix, elementDeclaration.getName());
-		} else if (elementDeclaration.isEmpty()) {
+			if(autoCloseTags) {
+				xml.endElement(prefix, elementDeclaration.getName());
+			}
+		} else if (elementDeclaration.isEmpty() && autoCloseTags) {
 			xml.endElement();
 		} else {
 			xml.closeStartElement();
@@ -109,7 +119,9 @@ public class XMLGenerator {
 				snippetIndex++;
 				xml.addContent("$" + snippetIndex);
 			}
-			xml.endElement(prefix, elementDeclaration.getName());
+			if(autoCloseTags) {
+				xml.endElement(prefix, elementDeclaration.getName());
+			}
 		}
 		return snippetIndex;
 	}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/CompletionRequest.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/CompletionRequest.java
@@ -69,8 +69,9 @@ class CompletionRequest extends AbstractPositionRequest implements ICompletionRe
 
 	public XMLGenerator getXMLGenerator() throws BadLocationException {
 		if (generator == null) {
-			generator = new XMLGenerator(getFormattingSettings(), getLineIndentInfo().getWhitespacesIndent(),
-					getLineIndentInfo().getLineDelimiter(), getCompletionSettings().isCompletionSnippetsSupported(), 0);
+			generator = new XMLGenerator(getFormattingSettings(), getCompletionSettings().isAutoCloseTags(), 
+					getLineIndentInfo().getWhitespacesIndent(), getLineIndentInfo().getLineDelimiter(), 
+					getCompletionSettings().isCompletionSnippetsSupported(), 0);
 		}
 		return generator;
 	}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLCompletions.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLCompletions.java
@@ -310,10 +310,14 @@ class XMLCompletions {
 							xml.append(" />");
 						} else {
 							xml.append(">");
-							if (completionRequest.getCompletionSettings().isCompletionSnippetsSupported()) {
+							CompletionSettings completionSettings = completionRequest.getCompletionSettings();
+
+							if (completionSettings.isCompletionSnippetsSupported()) {
 								xml.append("$0");
 							}
-							xml.append("</").append(tag).append(">");
+							if(completionSettings.isAutoCloseTags()) {
+								xml.append("</").append(tag).append(">");
+							}
 						}
 						item.setTextEdit(new TextEdit(replaceRange, xml.toString()));
 						item.setInsertTextFormat(InsertTextFormat.Snippet);

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/CompletionSettings.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/CompletionSettings.java
@@ -20,12 +20,38 @@ public class CompletionSettings {
 
 	private CompletionCapabilities completionCapabilities;
 
-	public void update(CompletionCapabilities completionCapabilities) {
+	private boolean autoCloseTags;
+
+	public CompletionSettings(boolean autoCloseTags) {
+		this.autoCloseTags = autoCloseTags;
+	}
+
+	public CompletionSettings() {
+		this(true);
+	}
+
+	public void setCapabilities(CompletionCapabilities completionCapabilities) {
 		this.completionCapabilities = completionCapabilities;
 	}
 
 	public CompletionCapabilities getCompletionCapabilities() {
 		return completionCapabilities;
+	}
+
+	/**
+	 * Tag should be autoclosed with an end tag.
+	 * @param autoCloseTags
+	 */
+	public void setAutoCloseTags(boolean autoCloseTags) {
+		this.autoCloseTags = autoCloseTags;
+	}
+
+	/**
+	 * If tag should be autoclosed with an end tag.
+	 * @return
+	 */
+	public boolean isAutoCloseTags() {
+		return autoCloseTags;
 	}
 
 	/**

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/XMLClientSettings.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/XMLClientSettings.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.lsp4xml.settings;
 
+import org.eclipse.lsp4xml.services.extensions.CompletionSettings;
 import org.eclipse.lsp4xml.utils.JSONUtility;
 
 /**
@@ -23,6 +24,8 @@ public class XMLClientSettings {
 	private XMLFormattingOptions format;
 	
 	private XMLExperimentalCapabilities experimental;
+
+	private CompletionSettings completion;
 
 	public void setLogs(LogsSettings logs) {
 		this.logs = logs;
@@ -43,6 +46,23 @@ public class XMLClientSettings {
 	public XMLExperimentalCapabilities getExperimental() {
 		return experimental;
 	}
+
+	/**
+	 * Set completion settings
+	 * @param completion
+	 */
+	public void setCompletion(CompletionSettings completion) {
+		this.completion = completion;
+	}
+
+	/**
+	 * Get completion settings
+	 * @param completion
+	 */
+	public CompletionSettings getCompletion() {
+		return completion;
+	}
+
 
 	public static XMLClientSettings getSettings(Object initializationOptionsSettings) {
 		return JSONUtility.toModel(initializationOptionsSettings, XMLClientSettings.class);

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/XMLAssert.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/XMLAssert.java
@@ -48,11 +48,15 @@ public class XMLAssert {
 
 	public static void testCompletionFor(String value, String catalogPath, String fileURI, Integer expectedCount,
 			CompletionItem... expectedItems) throws BadLocationException {
-		testCompletionFor(new XMLLanguageService(), value, catalogPath, fileURI, expectedCount, expectedItems);
+		testCompletionFor(new XMLLanguageService(), value, catalogPath, fileURI, expectedCount, true, expectedItems);
+	}
+
+	public static void testCompletionFor(String value, boolean autoCloseTags, CompletionItem... expectedItems) throws BadLocationException {
+		testCompletionFor(new XMLLanguageService(), value, null, null, null, autoCloseTags, expectedItems);
 	}
 
 	public static void testCompletionFor(XMLLanguageService xmlLanguageService, String value, String catalogPath,
-			String fileURI, Integer expectedCount, CompletionItem... expectedItems) throws BadLocationException {
+			String fileURI, Integer expectedCount, boolean autoCloseTags, CompletionItem... expectedItems) throws BadLocationException {
 		int offset = value.indexOf('|');
 		value = value.substring(0, offset) + value.substring(offset + 1);
 
@@ -66,7 +70,7 @@ public class XMLAssert {
 			settings.setCatalogs(new String[] { catalogPath });
 			xmlLanguageService.updateSettings(settings);
 		}
-		CompletionList list = xmlLanguageService.doComplete(htmlDoc, position, new CompletionSettings(),
+		CompletionList list = xmlLanguageService.doComplete(htmlDoc, position, new CompletionSettings(autoCloseTags),
 				new XMLFormattingOptions(4, false));
 
 		// no duplicate labels

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/extensions/HTMLCompletionExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/extensions/HTMLCompletionExtensionsTest.java
@@ -115,7 +115,7 @@ public class HTMLCompletionExtensionsTest {
 	}
 
 	public static void testCompletionFor(String value, CompletionItem... expectedItems) throws BadLocationException {
-		XMLAssert.testCompletionFor(new HTMLLanguageService(), value, null, null, null, expectedItems);
+		XMLAssert.testCompletionFor(new HTMLLanguageService(), value, null, null, null, true, expectedItems);
 	}
 
 	private static class HTMLLanguageService extends XMLLanguageService {


### PR DESCRIPTION
Fixes #130 Fixes #82