### PR TITLE
Fixes indentation issue for schema based attributes

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/utils/XMLGenerator.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/utils/XMLGenerator.java
@@ -134,23 +134,28 @@ public class XMLGenerator {
 
 	private int generate(Collection<CMAttributeDeclaration> attributes, int level, int snippetIndex, XMLBuilder xml, String tagName) {
 		int attributeIndex = 0;
-		int attributesSize = attributes.size();
-		for (CMAttributeDeclaration attributeDeclaration : attributes) {
-			if (attributeDeclaration.isRequired()) {
-				String value = attributeDeclaration.getDefaultValue();
-				if (canSupportSnippets) {
-					snippetIndex++;
-					value = ("$" + snippetIndex);
-				}
-				if(attributesSize != 1) {
-					xml.addAttributes(attributeDeclaration.getName(), value, attributeIndex, level, tagName);
-				}
-				else {
-					xml.addSingleAttribute(attributeDeclaration.getName(), value);
-				}
-				
-				attributeIndex++;
+		
+		ArrayList<CMAttributeDeclaration> requiredAttributes = new ArrayList<CMAttributeDeclaration>();
+		for (CMAttributeDeclaration att: attributes) {
+			if(att.isRequired()) {
+				requiredAttributes.add(att);
 			}
+		}
+		int attributesSize = requiredAttributes.size();
+		for (CMAttributeDeclaration attributeDeclaration : requiredAttributes) {
+			String value = attributeDeclaration.getDefaultValue();
+			if (canSupportSnippets) {
+				snippetIndex++;
+				value = ("$" + snippetIndex);
+			}
+			if(attributesSize != 1) {
+				xml.addAttributes(attributeDeclaration.getName(), value, attributeIndex, level, tagName);
+			}
+			else {
+				xml.addSingleAttribute(attributeDeclaration.getName(), value);
+			}
+			
+			attributeIndex++;
 		}
 		return snippetIndex;
 	}

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
@@ -241,6 +241,15 @@ public class XMLSchemaCompletionExtensionsTest {
 	}
 
 	@Test
+	public void schemaLocationWithElementAndAttributeCompletion() throws BadLocationException {
+		String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n" + //
+				"<invoice xmlns=\"http://simpleAttribute\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n"
+				+ " xsi:schemaLocation=\"http://simpleAttribute xsd/simpleAttribute.xsd \">\r\n" + //
+				"  <pro|</invoice>";
+		XMLAssert.testCompletionFor(xml, null, "src/test/resources/simpleAttribute.xml", null, c("product", "<product description=\"\" />"));
+	}
+
+	@Test
 	public void completionWithoutStartBracket() throws BadLocationException {
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
 				"<beans xmlns=\"http://www.springframework.org/schema/beans\" xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n"

--- a/org.eclipse.lsp4xml/src/test/resources/xsd/simpleAttribute.xsd
+++ b/org.eclipse.lsp4xml/src/test/resources/xsd/simpleAttribute.xsd
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+    elementFormDefault="qualified"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:element
+      name="invoice"
+      type="invoiceType"></xsd:element>
+  <xsd:complexType name="invoiceType">
+    <xsd:annotation>
+      <xsd:documentation>An invoice type...</xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element
+          name="product"
+          type="productType"></xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+      
+  <xsd:complexType name="productType">
+    <xsd:attribute
+        name="description"
+        type="xsd:string"
+        use="required"></xsd:attribute>
+  </xsd:complexType>
+
+</xsd:schema>


### PR DESCRIPTION
Fixes #188

The issue was that when adding attributes it  needed to know before hand how many attributes
would be added to know which add attribute method should be called.
.isRequired() was messing this up and was moved outside to determine the total variables being added
before the add attribute methods were called.