### PR TITLE
Adding root element 'xml' to preferences

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLLanguageServer.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLLanguageServer.java
@@ -37,9 +37,10 @@ import org.eclipse.lsp4xml.logs.LogHelper;
 import org.eclipse.lsp4xml.services.IXMLDocumentProvider;
 import org.eclipse.lsp4xml.services.XMLLanguageService;
 import org.eclipse.lsp4xml.services.extensions.CompletionSettings;
+import org.eclipse.lsp4xml.settings.AllXMLSettings;
 import org.eclipse.lsp4xml.settings.InitializationOptionsSettings;
 import org.eclipse.lsp4xml.settings.LogsSettings;
-import org.eclipse.lsp4xml.settings.XMLClientSettings;
+import org.eclipse.lsp4xml.settings.XMLGeneralClientSettings;
 import org.eclipse.lsp4xml.settings.XMLExperimentalCapabilities;
 import org.eclipse.lsp4xml.settings.XMLFormattingOptions;
 import org.eclipse.lsp4xml.settings.capabilities.ServerCapabilitiesInitializer;
@@ -112,27 +113,27 @@ public class XMLLanguageServer
 			return;
 		}
 		// Update client settings
-
-		XMLClientSettings clientSettings = XMLClientSettings.getSettings(initializationOptionsSettings);
-		if (clientSettings != null) {
+		initializationOptionsSettings = AllXMLSettings.getAllXMLSettings(initializationOptionsSettings);
+		XMLGeneralClientSettings xmlClientSettings = XMLGeneralClientSettings.getGeneralXMLSettings(initializationOptionsSettings);
+		if (xmlClientSettings != null) {
 			// Update logs settings
-			LogsSettings logsSettings = clientSettings.getLogs();
+			LogsSettings logsSettings = xmlClientSettings.getLogs();
 			if (logsSettings != null) {
 				LogHelper.initializeRootLogger(languageClient, logsSettings);
 			}
 			// Update format settings
-			XMLFormattingOptions formatterSettings = clientSettings.getFormat();
+			XMLFormattingOptions formatterSettings = xmlClientSettings.getFormat();
 			if (formatterSettings != null) {
 				xmlTextDocumentService.getSharedFormattingOptions().merge(formatterSettings);
 			}
 
-			CompletionSettings newCompletions = clientSettings.getCompletion();
+			CompletionSettings newCompletions = xmlClientSettings.getCompletion();
 			if (newCompletions != null) {
 				xmlTextDocumentService.updateCompletionSettings(newCompletions);
 			}
 
 			// Experimental capabilities
-			XMLExperimentalCapabilities experimental = clientSettings.getExperimental();
+			XMLExperimentalCapabilities experimental = xmlClientSettings.getExperimental();
 			if (experimental != null) {
 				boolean incrementalSupport = experimental.getIncrementalSupport() != null
 						&& experimental.getIncrementalSupport().getEnabled() != null

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/ContentModelPlugin.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/ContentModelPlugin.java
@@ -75,7 +75,7 @@ public class ContentModelPlugin implements IXMLExtension {
 
 	private void updateSettings(ISaveContext saveContext) {
 		Object initializationOptionsSettings = saveContext.getSettings();
-		cmSettings = ContentModelSettings.getSettings(initializationOptionsSettings);
+		cmSettings = ContentModelSettings.getContentModelXMLSettings(initializationOptionsSettings);
 		if (cmSettings != null) {
 			updateSettings(cmSettings, saveContext);
 		}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/settings/ContentModelSettings.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/settings/ContentModelSettings.java
@@ -88,7 +88,7 @@ public class ContentModelSettings {
 		this.problems = problems;
 	}
 
-	public static ContentModelSettings getSettings(Object initializationOptionsSettings) {
+	public static ContentModelSettings getContentModelXMLSettings(Object initializationOptionsSettings) {
 		return JSONUtility.toModel(initializationOptionsSettings, ContentModelSettings.class);
 	}
 

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/AllXMLSettings.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/AllXMLSettings.java
@@ -1,0 +1,50 @@
+/**
+ *  Copyright (c) 2018 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Red Hat <nkomonen@redhat.com> - initial API and implementation
+ */
+
+package org.eclipse.lsp4xml.settings;
+
+import com.google.gson.annotations.JsonAdapter;
+
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
+import org.eclipse.lsp4xml.utils.JSONUtility;
+
+/**
+ * Represents all settings under the 'xml' key
+ * 
+ * {
+ *  'xml': {...} 
+ * } 
+ */
+public class AllXMLSettings {
+
+	@JsonAdapter(JsonElementTypeAdapter.Factory.class)
+	private Object xml;
+
+	/**
+	 * @return the xml
+	 */
+	public Object getXml() {
+		return xml;
+	}
+
+	/**
+	 * @param xml the xml to set
+	 */
+	public void setXml(Object xml) {
+		
+		this.xml = xml;
+	}
+
+	public static Object getAllXMLSettings(Object initializationOptionsSettings) {
+		AllXMLSettings settings = JSONUtility.toModel(initializationOptionsSettings, AllXMLSettings.class);
+		return settings != null ? settings.getXml() : null;
+	}
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/InitializationOptionsSettings.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/InitializationOptionsSettings.java
@@ -1,3 +1,14 @@
+/**
+ *  Copyright (c) 2018 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+
 package org.eclipse.lsp4xml.settings;
 
 import org.eclipse.lsp4j.InitializeParams;
@@ -6,6 +17,16 @@ import org.eclipse.lsp4xml.utils.JSONUtility;
 
 import com.google.gson.annotations.JsonAdapter;
 
+/**
+ * Represents all settings sent from the server
+ * 
+ * {
+ *   'settings': {
+ *       'xml': {...},
+ *       'http': {...}
+ *   }
+ * }
+ */
 public class InitializationOptionsSettings {
 
 	@JsonAdapter(JsonElementTypeAdapter.Factory.class)
@@ -28,17 +49,20 @@ public class InitializationOptionsSettings {
 	 * <pre>
 	 * "initializationOptions": {
 			"settings": {
-			    "catalogs": [
-			      "catalog.xml",
-			      "catalog2.xml"
-			    ],
-			    "logs": {
-			      "client": true
-			    },
-			    "format": {
-			      "joinCommentLines": false,
-			      "formatComments": true
-			    }
+				"xml": {
+					"catalogs": [
+						"catalog.xml",
+						"catalog2.xml"
+					],
+					"logs": {
+						"client": true
+					},
+					"format": {
+						"joinCommentLines": false,
+						"formatComments": true
+					},
+					...
+				}
 			}
 		}
 	 * </pre>

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/XMLGeneralClientSettings.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/XMLGeneralClientSettings.java
@@ -17,7 +17,7 @@ import org.eclipse.lsp4xml.utils.JSONUtility;
  * XML client settings
  *
  */
-public class XMLClientSettings {
+public class XMLGeneralClientSettings {
 
 	private LogsSettings logs;
 
@@ -63,8 +63,8 @@ public class XMLClientSettings {
 		return completion;
 	}
 
-
-	public static XMLClientSettings getSettings(Object initializationOptionsSettings) {
-		return JSONUtility.toModel(initializationOptionsSettings, XMLClientSettings.class);
+	public static XMLGeneralClientSettings getGeneralXMLSettings(Object initializationOptionsSettings) {
+		return JSONUtility.toModel(initializationOptionsSettings, XMLGeneralClientSettings.class);
 	}
+	
 }

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/settings/SettingsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/settings/SettingsTest.java
@@ -26,30 +26,33 @@ public class SettingsTest {
 
 	@Test
 	public void initializationOptionsSettings() {
-		String json = "{\r\n" + //
+		String json = 
+				"{\r\n" + //
 				"	\"settings\": {\r\n" + //
 				// Content model settings
-				"		\"fileAssociations\": [\r\n" + //
-				"			{\r\n" + //
-				"				\"systemId\": \"src\\\\test\\\\resources\\\\xsd\\\\spring-beans-3.0.xsd\",\r\n" + //
-				"				\"pattern\": \"**/test*.xml\"\r\n" + //
-				"			},\r\n" + //
-				"			{\r\n" + //
-				"				\"systemId\": \"src\\\\test\\\\resources\\\\xsd\\\\projectDescription.xsd\",\r\n" + //
-				"				\"pattern\": \"projectDescription.xml\"\r\n" + //
-				"			}\r\n" + //
-				"		],\r\n" + //
-				"		\"catalogs\": [\r\n" + //
-				"			\"src\\\\test\\\\resources\\\\catalogs\\\\catalog.xml\"\r\n" + //
-				"		],\r\n" + //
+				"		\"xml\": {\r\n" +
+				"			\"fileAssociations\": [\r\n" + //
+				"				{\r\n" + //
+				"					\"systemId\": \"src\\\\test\\\\resources\\\\xsd\\\\spring-beans-3.0.xsd\",\r\n" + //
+				"					\"pattern\": \"**/test*.xml\"\r\n" + //
+				"				},\r\n" + //
+				"				{\r\n" + //
+				"					\"systemId\": \"src\\\\test\\\\resources\\\\xsd\\\\projectDescription.xsd\",\r\n" + //
+				"					\"pattern\": \"projectDescription.xml\"\r\n" + //
+				"				}\r\n" + //
+				"			],\r\n" + //
+				"			\"catalogs\": [\r\n" + //
+				"				\"src\\\\test\\\\resources\\\\catalogs\\\\catalog.xml\"\r\n" + //
+				"			],\r\n" + //
 				// Client (commons) settings				
-				"		\"format\": {\r\n" + //
-				"			\"tabSize\": 10,\r\n" + //
-				"			\"insertSpaces\": false,\r\n" + //
-				"			\"splitAttributes\": true,\r\n" + //
-				"			\"joinCDATALines\": true,\r\n" + //
-				"			\"formatComments\": true,\r\n" + //
-				"			\"joinCommentLines\": true\r\n" + //
+				"			\"format\": {\r\n" + //
+				"				\"tabSize\": 10,\r\n" + //
+				"				\"insertSpaces\": false,\r\n" + //
+				"				\"splitAttributes\": true,\r\n" + //
+				"				\"joinCDATALines\": true,\r\n" + //
+				"				\"formatComments\": true,\r\n" + //
+				"				\"joinCommentLines\": true\r\n" + //
+				"			}\r\n" + 
 				"		}\r\n" + 
 				"	}\r\n" + 
 				"}";
@@ -60,11 +63,12 @@ public class SettingsTest {
 		Object initializationOptionsSettings = InitializationOptionsSettings.getSettings(params);
 
 		// Test client commons settings
-		XMLClientSettings settings = XMLClientSettings.getSettings(initializationOptionsSettings);
+		initializationOptionsSettings = AllXMLSettings.getAllXMLSettings(initializationOptionsSettings);
+		XMLGeneralClientSettings settings = XMLGeneralClientSettings.getGeneralXMLSettings(initializationOptionsSettings);
 		Assert.assertNotNull(settings);
 
 		// Test content model extension settings
-		ContentModelSettings cmSettings = ContentModelSettings.getSettings(initializationOptionsSettings);
+		ContentModelSettings cmSettings = ContentModelSettings.getContentModelXMLSettings(initializationOptionsSettings);
 		Assert.assertNotNull(cmSettings);
 		// Catalog
 		Assert.assertNotNull(cmSettings.getCatalogs());


### PR DESCRIPTION
Fixes #257, wiki will be updated after merge.

This will require a modification to the wiki. With the addition of the 'xml' key under settings:

**Old:**
```json
  {
        "settings": {
                "trace": {
                    "server": "verbose"
                },
                "catalogs": [],
                "format": {
                    "splitAttributes": true,
                    "joinCDATALines": false,
                    "joinContentLines": false,
                    "joinCommentLines": false,
                    "spaceBeforeEmptyCloseTag": false,
                    "enabled": true
                },
               ...
          }
  }
```
**New:**
```json
  {
        "settings": {
            "xml": {
                "trace": {
                    "server": "verbose"
                },
                "catalogs": [],
                "format": {
                    "splitAttributes": true,
                    "joinCDATALines": false,
                    "joinContentLines": false,
                    "joinCommentLines": false,
                    "spaceBeforeEmptyCloseTag": false,
                    "enabled": true
                },
               ...
            }
        }
  }
```