### PR TITLE
Rename *-all.jar to *-uber.jar to minimize confusion about its contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Get started
 * Clone this repository
 * Open the folder in your terminal / command line
 * Run `./mvnw clean verify` (OSX, Linux) or `mvnw.cmd clean verify` (Windows)
-* After successful compilation you can find the resulting `org.eclipse.lsp4xml-all.jar` in the folder `org.eclipse.lsp4xml/target`
+* After successful compilation you can find the resulting `org.eclipse.lsp4xml-uber.jar` in the folder `org.eclipse.lsp4xml/target`
 
 Developer
 --------------

--- a/org.eclipse.lsp4xml/src/assembly/distribution.xml
+++ b/org.eclipse.lsp4xml/src/assembly/distribution.xml
@@ -5,7 +5,7 @@
   Copied from jar-with-dependencies because we want to both control the local name 
   AND attach the binary to the project build artifacts. Workaround for https://issues.apache.org/jira/browse/MASSEMBLY-824
    -->
-  <id>all</id>
+  <id>uber</id>
   <formats>
     <format>jar</format>
   </formats>


### PR DESCRIPTION
See #229