### PR TITLE
Modifying schema validation messages

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,19 @@
+   =========================================================================
+   ==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+   ==  Version 2.0, in this case for the Apache Xerces Java distribution. ==
+   =========================================================================
+
+	---------------------------------------------------------------------------
+   Apache Xerces Java
+   Copyright 1999-2018 The Apache Software Foundation
+
+   This product includes software developed at
+   The Apache Software Foundation (http://www.apache.org/).
+
+   Portions of this software were originally based on the following:
+     - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
+     - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
+     - voluntary contributions made by Paul Eng on behalf of the 
+       Apache Software Foundation that were originally developed at iClick, Inc.,
+       software copyright (c) 1999.
+	---------------------------------------------------------------------------

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/parser/Constants.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/parser/Constants.java
@@ -33,6 +33,8 @@ public class Constants {
 	public final static int _CSB = "]".codePointAt(0);
 	public final static int _ORB = "(".codePointAt(0);
 	public final static int _CRB = ")".codePointAt(0);
+	public final static int _OCB = "{".codePointAt(0);
+	public final static int _CCB = "}".codePointAt(0);
 	public final static int _CVL = "C".codePointAt(0);
 	public final static int _DVL = "D".codePointAt(0);
 	public final static int _AVL = "A".codePointAt(0);

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/parser/MultiLineStream.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/parser/MultiLineStream.java
@@ -30,7 +30,7 @@ import java.util.regex.Pattern;
  * Multi line stream.
  *
  */
-class MultiLineStream {
+public class MultiLineStream {
 
 	private static final Predicate<Integer> WHITESPACE_PREDICATE = ch -> {
 		return ch == _WSP || ch == _TAB || ch == _NWL || ch == _LFD || ch == _CAR;

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/XMLSchemaErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/XMLSchemaErrorCode.java
@@ -34,7 +34,6 @@ import org.eclipse.lsp4xml.utils.XMLPositionUtility;
  *
  */
 public enum XMLSchemaErrorCode implements IXMLErrorCode {
-
 	cvc_complex_type_2_3("cvc-complex-type.2.3"), // https://wiki.xmldation.com/Support/Validator/cvc-complex-type-2-3
 	cvc_complex_type_2_1("cvc-complex-type.2.1"), // https://wiki.xmldation.com/Support/Validator/cvc-complex-type-2-1
 	cvc_complex_type_2_4_a("cvc-complex-type.2.4.a"), // https://wiki.xmldation.com/Support/Validator/cvc-complex-type-2-4-a
@@ -57,7 +56,9 @@ public enum XMLSchemaErrorCode implements IXMLErrorCode {
 	cvc_maxExclusive_valid("cvc-maxExclusive-valid"), // https://wiki.xmldation.com/Support/validator/cvc-maxexclusive-valid
 	cvc_maxInclusive_valid("cvc-maxInclusive-valid"), // https://wiki.xmldation.com/Support/validator/cvc-maxinclusive-valid
 	cvc_minExclusive_valid("cvc-minExclusive-valid"), // https://wiki.xmldation.com/Support/validator/cvc-minexclusive-valid
-	cvc_minInclusive_valid("cvc-minInclusive-valid"); // https://wiki.xmldation.com/Support/validator/cvc-mininclusive-valid
+	cvc_minInclusive_valid("cvc-minInclusive-valid"), // https://wiki.xmldation.com/Support/validator/cvc-mininclusive-valid
+	TargetNamespace_2("TargetNamespace.2"),
+	schema_reference_4("schema_reference.4"); // 
 
 	private final String code;
 
@@ -117,6 +118,7 @@ public enum XMLSchemaErrorCode implements IXMLErrorCode {
 		case cvc_complex_type_2_4_d:
 		case cvc_elt_1_a:
 		case cvc_complex_type_4:
+		case TargetNamespace_2:
 			return XMLPositionUtility.selectStartTag(offset, document);
 		case cvc_complex_type_3_2_2: {
 			String attrName = (String) arguments[1];

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/diagnostics/AbstractLSPErrorReporter.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/diagnostics/AbstractLSPErrorReporter.java
@@ -49,7 +49,7 @@ public abstract class AbstractLSPErrorReporter extends XMLErrorReporter {
 		XMLMessageFormatter xmft = new XMLMessageFormatter();
 		super.putMessageFormatter(XMLMessageFormatter.XML_DOMAIN, xmft);
 		super.putMessageFormatter(XMLMessageFormatter.XMLNS_DOMAIN, xmft);
-		super.putMessageFormatter(XSMessageFormatter.SCHEMA_DOMAIN, new XSMessageFormatter());
+		super.putMessageFormatter(XSMessageFormatter.SCHEMA_DOMAIN, new LSPMessageFormatter());
 	}
 
 	public String reportError(XMLLocator location, String domain, String key, Object[] arguments, short severity,

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/diagnostics/LSPMessageFormatter.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/diagnostics/LSPMessageFormatter.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.lsp4xml.services.extensions.diagnostics;
+
+import java.util.Locale;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.xerces.util.MessageFormatter;
+
+import org.eclipse.lsp4xml.dom.parser.MultiLineStream;
+import org.eclipse.lsp4xml.extensions.contentmodel.participants.XMLSchemaErrorCode;
+
+import static org.eclipse.lsp4xml.dom.parser.Constants.*;
+
+/**
+ * SchemaMessageProvider implements an XMLMessageProvider that provides
+ * localizable error messages for the W3C XML Schema Language
+ * 
+ * @xerces.internal
+ * 
+ * @author Elena Litani, IBM
+ * @version $Id: XSMessageFormatter.java 813087 2009-09-09 19:35:27Z mrglavas $
+ * 
+ * Modified to use additional resource bundle
+ * 
+ * @author Red Hat Inc. <nkomonen@redhat.com>
+ */
+public class LSPMessageFormatter implements MessageFormatter {
+	/**
+	 * The domain of messages concerning the XML Schema: Structures specification.
+	 */
+	public static final String SCHEMA_DOMAIN = "http://www.w3.org/TR/xml-schema-1";
+
+	// private objects to cache the locale and resource bundle
+	private Locale fLocale = null;
+	private ResourceBundle fResourceBundle = null;
+	private ResourceBundle newResourceBundle = null;
+
+	/**
+	 * Formats a message with the specified arguments using the given locale
+	 * information.
+	 * 
+	 * @param locale    The locale of the message.
+	 * @param key       The message key.
+	 * @param arguments The message replacement text arguments. The order of the
+	 *                  arguments must match that of the placeholders in the actual
+	 *                  message.
+	 * 
+	 * @return Returns the formatted message.
+	 *
+	 * @throws MissingResourceException Thrown if the message with the specified key
+	 *                                  cannot be found.
+	 */
+	public String formatMessage(Locale locale, String key, Object[] arguments) throws MissingResourceException {
+
+		if (locale == null) {
+			locale = Locale.getDefault();
+		}
+		if (locale != fLocale) {
+			fResourceBundle = ResourceBundle.getBundle("org.apache.xerces.impl.msg.XMLSchemaMessages", locale);
+			newResourceBundle = ResourceBundle.getBundle("XMLSchemaMessagesReformatted", locale); // in src/main/resources
+			
+			fLocale = locale;
+		}
+
+		boolean usedNewResourceBundle = false;
+	
+		String msg =  null;
+		
+		try {
+			msg = newResourceBundle.getString(key);
+			usedNewResourceBundle = true;
+		} catch (NullPointerException | MissingResourceException e) {
+			msg = fResourceBundle.getString(key);
+		}
+		
+		if (arguments != null) {
+			try {
+				
+				if(usedNewResourceBundle) {
+					arguments = reformatSchemaArguments(XMLSchemaErrorCode.get(key), arguments);
+				}
+				
+				msg = java.text.MessageFormat.format(msg, arguments);
+			} catch (Exception e) {
+				msg = fResourceBundle.getString("FormatFailed");
+				msg += " " + fResourceBundle.getString(key);
+			}
+		}
+
+		if (msg == null) {
+			msg = fResourceBundle.getString("BadMessageKey");
+			throw new MissingResourceException(msg, "XMLSchemaMessages", key);
+		}
+
+		return msg;
+	}
+
+	/**
+	 * Modifies the schema message arguments to a cleaned down format
+	 * 
+	 * @param code
+	 * @param message
+	 * @return
+	 */
+	public static Object[] reformatSchemaArguments(XMLSchemaErrorCode code, Object[] arguments) {
+
+		switch (code) {
+			case cvc_complex_type_2_4_a:
+				return cvc_2_4_a_solution(arguments);
+			case cvc_complex_type_2_4_b:
+				return cvc_2_4_b_solution(arguments);
+			case cvc_enumeration_valid:
+				return enumeration_valid_solution(arguments);
+			case cvc_complex_type_4:
+				arguments[1] = "- " + arguments[1];
+				arguments[0] = "- " + arguments[0];
+			default:
+				return arguments;
+		}
+	}
+
+	private static String reformatElementNames(boolean hasNamespace, String names) {
+		StringBuilder sb = new StringBuilder();
+
+		MultiLineStream stream = new MultiLineStream(names, 0);
+
+		while (!stream.eos()) { // }
+			stream.advance(1);// Consume ' ' or '{' if first item
+			if(hasNamespace) {
+				stream.advance(1); // Consume "
+				stream.advanceUntilAnyOfChars(_DQO, _SQO, _SIQ); // " | " | '
+				stream.advance(2); // Consume quotation and':'
+			}
+			sb.append(" - ");
+			while (stream.peekChar() != _CCB && stream.peekChar() != _CMA) { // } | ,
+				sb.append(Character.toString((char) stream.peekChar()));
+				stream.advance(1);
+			}
+			sb.append("\n");
+			//if (stream.peekChar() == _CMA) {
+				stream.advance(1);
+			//}
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Reformats a string of format:
+	 * "[name1, name2, name3]"
+	 * @param names
+	 * @return
+	 */
+	private static String reformatArrayElementNames(String names) {
+		StringBuilder sb = new StringBuilder();
+
+		MultiLineStream stream = new MultiLineStream(names, 0);
+
+		while (!stream.eos()) { // ]
+			stream.advance(1);// Consume ' ' or '[' if first item
+			sb.append(" - ");
+			while (stream.peekChar() != _CSB && stream.peekChar() != _CMA) { // ] | ,
+				sb.append(Character.toString((char) stream.peekChar()));
+				stream.advance(1);
+			}
+			sb.append("\n");
+			stream.advance(1); // Consume , or ]
+			
+		}
+		return sb.toString();
+	}
+
+	/**
+	 * Returns a pattern matcher looking
+	 * for a string that matches the format of: 
+	 * 		"{"http://maven.apache.org/POM/4.0.0":propertiesa}"
+	 * @param name
+	 * @return
+	 */
+	private static Matcher getNamespaceMatcher(String name) {
+		Pattern namespacePattern = Pattern.compile("^\\{\"(.*)\":(.*)(\\}|,)");
+		return namespacePattern.matcher(name);
+	}
+
+	// private static boolean isNamespaceDefined(String name) {
+	// 	return getNamespaceMatcher(name).matches();
+	// }
+
+	/**
+	 * Parses the message for cvc.2.4.a and returns reformatted arguments
+	 * 
+	 * With Namespace
+	 * 
+	 * arguments[0]: {"http://maven.apache.org/POM/4.0.0":propertiesa} 
+	 * arguments[1]: {"http://maven.apache.org/POM/4.0.0":groupId, "http://maven.apache.org/POM/4.0.0":version}
+	 * 
+	 * Without Namespace
+	 * 
+	 * arguments[0]: propertiesa
+	 * arguments[1]: {groupId, version}
+	 * 
+	 * @param arguments
+	 * @return
+	 */
+	private static Object[] cvc_2_4_a_solution(Object[] arguments) {
+		Matcher m = getNamespaceMatcher((String) arguments[0]);
+		String schema = null;
+		String name = null;
+		String validNames = null;
+	
+		if (m.matches()) {
+			name = m.group(2);
+			schema = "{" + m.group(1) + "}";
+			validNames = reformatElementNames(true, (String)arguments[1]);
+		} else { // No namespace, so just element name
+			name = (String) arguments[0];
+			schema = "{the schema}";
+			validNames = reformatElementNames(false, (String)arguments[1]);
+		}
+		name = "- " + name;
+		return new Object[] { name, validNames, schema };
+	}	
+
+	/**
+	 * Parses the message for cvc.2.4.b and returns reformatted arguments
+	 * 
+	 * With Namespace
+	 * 
+	 * arguments[0]: elementName
+	 * arguments[1]: {"http://maven.apache.org/POM/4.0.0":groupId, "http://maven.apache.org/POM/4.0.0":version}
+	 * 
+	 * Without Namespace
+	 * 
+	 * arguments[0]: elementName
+	 * arguments[1]: {groupId, version}
+	 * 
+	 * @param arguments
+	 * @return
+	 */
+	private static Object[] cvc_2_4_b_solution(Object[] arguments) {
+		Matcher m = getNamespaceMatcher((String) arguments[1]);
+
+		String element = null;
+		String missingChildElements = null;
+		String schema = null;
+	
+		if (m.matches()) {
+			missingChildElements = reformatElementNames(true, (String)arguments[1]);
+			schema = "{" + m.group(1) + "}";
+		} else { 
+			// No namespace, so just element name
+			missingChildElements = reformatElementNames(false, (String)arguments[1]);
+			schema = "{the schema}";
+		}
+		element = "- " + (String) arguments[0];
+		return new Object[] { element, missingChildElements , schema };
+	}	
+
+	public static Object[] enumeration_valid_solution(Object[] arguments) {
+		return new Object[] { (String) arguments[0], reformatArrayElementNames((String)arguments[1])};
+	}
+}

--- a/org.eclipse.lsp4xml/src/main/resources/XMLSchemaMessagesReformatted.properties
+++ b/org.eclipse.lsp4xml/src/main/resources/XMLSchemaMessagesReformatted.properties
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This file contains error and warning messages related to XML Schema
+# The messages are arranged in key and value tuples in a ListResourceBundle.
+#
+# @version $Id$
+
+    # changed
+				cvc-complex-type.2.3 = Element ''{0}'' cannot contain text content.\nThe content type is defined as element-only.\n\nCode:
+	# changed
+				cvc-complex-type.2.4.a = Invalid element name:\n {0}\n\nOne of the following is expected:\n{1}\nError indicated by:\n {2}\nwith code:
+    # changed
+				cvc-complex-type.2.4.b = Child elements are missing from element:\n {0}\n\nThe following elements are expected:\n{1}\nError indicated by\n {2}\nwith code:
+    # changed
+				cvc-complex-type.4 = Attribute:\n {1}\nis required in element:\n {0}\n\nCode:
+    # changed
+				cvc-datatype-valid.1.2.1 = Content of type ''{1}'' is expected.\n\nThe following content is not a valid type:\n ''{0}''\n\nCode:
+    # changed
+				cvc-enumeration-valid = Value ''{0}'' is not in the enumeration list.\n\nIt must be one of the following:\n{1}\nCode:
+        
+
+
+        

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/XMLAssert.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/XMLAssert.java
@@ -280,10 +280,19 @@ public class XMLAssert {
 
 	public static void assertDiagnostics(List<Diagnostic> actual, List<Diagnostic> expected, boolean filter) {
 		List<Diagnostic> received = actual;
+		final boolean filterMessage;
+		if(expected != null && !expected.isEmpty() && expected.get(0).getMessage() != null) {
+			filterMessage = true;
+		} else {
+			filterMessage = false;
+		}
 		if (filter) {
 			received = actual.stream().map(d -> {
 				Diagnostic simpler = new Diagnostic(d.getRange(), null);
 				simpler.setCode(d.getCode());
+				if(filterMessage) {
+					simpler.setMessage(d.getMessage());
+				}
 				return simpler;
 			}).collect(Collectors.toList());
 		}
@@ -291,12 +300,17 @@ public class XMLAssert {
 	}
 
 	public static Diagnostic d(int startLine, int startCharacter, int endLine, int endCharacter, IXMLErrorCode code) {
-		return new Diagnostic(r(startLine, startCharacter, endLine, endCharacter), null, null, null, code.getCode());
+		return d(startLine, startCharacter, endLine, endCharacter, code, null);
 	}
 
 	public static Diagnostic d(int startLine, int startCharacter, int endCharacter, IXMLErrorCode code) {
 		// Diagnostic on 1 line
 		return d(startLine, startCharacter, startLine, endCharacter, code);
+	}
+
+	public static Diagnostic d(int startLine, int startCharacter, int endLine, int endCharacter, IXMLErrorCode code, String message) {
+		// Diagnostic on 1 line
+		return new Diagnostic(r(startLine, startCharacter, endLine, endCharacter), message, null, null, code.getCode());
 	}
 
 	public static Range r(int startLine, int startCharacter, int endLine, int endCharacter) {
@@ -335,7 +349,7 @@ public class XMLAssert {
 		Assert.assertEquals(expected.length, actual.size());
 		for (int i = 0; i < expected.length; i++) {
 			Assert.assertEquals(fileURI, actual.get(i).getUri());
-			assertDiagnostics(expected[i].getDiagnostics(), actual.get(i).getDiagnostics(), false);
+			assertDiagnostics(actual.get(i).getDiagnostics(), expected[i].getDiagnostics(), false);
 		}
 	}
 

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLFileAssociationsDiagnosticsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLFileAssociationsDiagnosticsTest.java
@@ -12,7 +12,6 @@ package org.eclipse.lsp4xml.extensions.contentmodel;
 
 import static org.eclipse.lsp4xml.XMLAssert.d;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.function.Consumer;
@@ -23,10 +22,8 @@ import com.google.gson.JsonObject;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4xml.XMLAssert;
-import org.eclipse.lsp4xml.XMLTextDocumentService;
 import org.eclipse.lsp4xml.XMLAssert.SettingsSaveContext;
 import org.eclipse.lsp4xml.commons.BadLocationException;
-import org.eclipse.lsp4xml.commons.TextDocument;
 import org.eclipse.lsp4xml.extensions.contentmodel.model.ContentModelManager;
 import org.eclipse.lsp4xml.extensions.contentmodel.participants.XMLSchemaErrorCode;
 import org.eclipse.lsp4xml.extensions.contentmodel.settings.ContentModelSettings;
@@ -41,7 +38,7 @@ import org.junit.Test;
  * XML file associations diagnostics tests.
  */
 public class XMLFileAssociationsDiagnosticsTest {
-
+	
 	@Test
 	public void validationOnRoot() throws BadLocationException {
 		Consumer<XMLLanguageService> configuration = ls -> {

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
@@ -36,7 +36,7 @@ public class XMLSchemaDiagnosticsTest {
 				"		XXXXXXXXXXXXX\r\n" + // <-- error
 				"	</bean>\r\n" + //
 				"</beans>";
-		Diagnostic d = d(3, 2, 3, 15, XMLSchemaErrorCode.cvc_complex_type_2_3);
+		Diagnostic d = d(3, 2, 3, 15, XMLSchemaErrorCode.cvc_complex_type_2_3, "Element \'bean\' cannot contain text content.\nThe content type is defined as element-only.\n\nCode:");
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(3, 2, 3, 15, "")));
 	}
@@ -50,7 +50,7 @@ public class XMLSchemaDiagnosticsTest {
 				"		<property></property>\r\n" + //
 				"	</bean>\r\n" + //
 				"</beans>";
-		Diagnostic d = d(3, 3, 3, 11, XMLSchemaErrorCode.cvc_complex_type_4);
+		Diagnostic d = d(3, 3, 3, 11, XMLSchemaErrorCode.cvc_complex_type_4, "Attribute:\n - name\nis required in element:\n - property\n\nCode:");
 		testDiagnosticsFor(xml, d);
 		testCodeActionsFor(xml, d, ca(d, te(3, 11, 3, 11, " name=\"\"")));
 	}
@@ -63,7 +63,9 @@ public class XMLSchemaDiagnosticsTest {
 				+ //
 				"	<XXX></XXX>\r\n" + // <- error
 				"</project>";
-		testDiagnosticsFor(xml, d(3, 2, 3, 5, XMLSchemaErrorCode.cvc_complex_type_2_4_a));
+
+		String message = "Invalid element name:\n - XXX\n\nOne of the following is expected:\n - modelVersion\n - parent\n - groupId\n - artifactId\n - version\n - packaging\n - name\n - description\n - url\n - inceptionYear\n - organization\n - licenses\n - developers\n - contributors\n - mailingLists\n - prerequisites\n - modules\n - scm\n - issueManagement\n - ciManagement\n - distributionManagement\n - properties\n - dependencyManagement\n - dependencies\n - repositories\n - pluginRepositories\n - build\n - reports\n - reporting\n - profiles\n\nError indicated by:\n {http://maven.apache.org/POM/4.0.0}\nwith code:";
+		testDiagnosticsFor(xml, d(3, 2, 3, 5, XMLSchemaErrorCode.cvc_complex_type_2_4_a, message));
 	}
 
 	@Test
@@ -293,7 +295,7 @@ public class XMLSchemaDiagnosticsTest {
 				+ //
 				"  \r\n" + //
 				"</edmx:Edmx>";
-		Diagnostic d = d(1, 1, 1, 10, XMLSchemaErrorCode.cvc_complex_type_2_4_b);
+		Diagnostic d = d(1, 1, 1, 10, XMLSchemaErrorCode.cvc_complex_type_2_4_b, "Child elements are missing from element:\n - edmx:Edmx\n\nThe following elements are expected:\n - Reference\n - DataServices\n\nError indicated by\n {http://docs.oasis-open.org/odata/ns/edmx\":Reference, \"http://docs.oasis-open.org/odata/ns/edmx}\nwith code:");
 		testDiagnosticsFor(xml, d);
 	}
 

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaPublishDiagnosticsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaPublishDiagnosticsTest.java
@@ -123,7 +123,7 @@ public class XMLSchemaPublishDiagnosticsTest extends AbstractCacheBasedTest {
 
 		XMLAssert.testPublishDiagnosticsFor(xml, fileURI, configuration, pd(fileURI, //
 				new Diagnostic(r(3, 8, 3, 26),
-						"cvc-datatype-valid.1.2.1: '2017-11-30_INVALID' is not a valid value for 'date'.",
+				"Content of type 'date' is expected.\n\nThe following content is not a valid type:\n '2017-11-30_INVALID'\n\nCode:",
 						DiagnosticSeverity.Error, "xml", XMLSchemaErrorCode.cvc_datatype_valid_1_2_1.getCode()), //
 				new Diagnostic(r(3, 8, 3, 26),
 						"cvc-type.3.1.3: The value '2017-11-30_INVALID' of element 'date' is not valid.",
@@ -167,7 +167,7 @@ public class XMLSchemaPublishDiagnosticsTest extends AbstractCacheBasedTest {
 
 		XMLAssert.testPublishDiagnosticsFor(xml, fileURI, configuration, pd(fileURI, //
 				new Diagnostic(r(3, 8, 3, 26),
-						"cvc-datatype-valid.1.2.1: '2017-11-30_INVALID' is not a valid value for 'date'.",
+						"Content of type 'date' is expected.\n\nThe following content is not a valid type:\n '2017-11-30_INVALID'\n\nCode:",
 						DiagnosticSeverity.Error, "xml", XMLSchemaErrorCode.cvc_datatype_valid_1_2_1.getCode()), //
 				new Diagnostic(r(3, 8, 3, 26),
 						"cvc-type.3.1.3: The value '2017-11-30_INVALID' of element 'date' is not valid.",


### PR DESCRIPTION
Fixes #181 

Before:

<img width="516" alt="screen shot 2019-02-25 at 12 34 22 pm" src="https://user-images.githubusercontent.com/32624665/53356601-c1be5800-38f9-11e9-983e-afa6340c3229.png">


After:

![selection_016](https://user-images.githubusercontent.com/32624665/53184071-6a06b080-35ca-11e9-8a59-393328f2ea3b.png)

---

Before:

<img width="639" alt="screen shot 2019-02-25 at 12 22 16 pm" src="https://user-images.githubusercontent.com/32624665/53355927-2d072a80-38f8-11e9-9389-cd1e887df95e.png">


After:

![selection_019](https://user-images.githubusercontent.com/32624665/53184215-a5a17a80-35ca-11e9-8d7c-1b7a21850299.png)

--- 

Before:
<img width="507" alt="screen shot 2019-02-25 at 12 08 45 pm" src="https://user-images.githubusercontent.com/32624665/53355141-5f178d00-38f6-11e9-812f-5c5c295b9254.png">

After: (Uses single quotes now)

![selection_021](https://user-images.githubusercontent.com/32624665/53184521-2eb8b180-35cb-11e9-8511-cbf921672eda.png)

---

Before:

<img width="549" alt="screen shot 2019-02-25 at 12 24 39 pm" src="https://user-images.githubusercontent.com/32624665/53355993-5e7ff600-38f8-11e9-9865-2c95ee5c8daf.png">

After:

![selection_022](https://user-images.githubusercontent.com/32624665/53184649-6c1d3f00-35cb-11e9-90af-7a243017e314.png)

---

Before:

<img width="522" alt="screen shot 2019-02-25 at 12 36 37 pm" src="https://user-images.githubusercontent.com/32624665/53356742-1b268700-38fa-11e9-89e0-cb6226a4c4e7.png">


After:

![selection_024](https://user-images.githubusercontent.com/32624665/53184806-b7375200-35cb-11e9-8701-6ba491e36a0e.png)

---

Before:

<img width="529" alt="screen shot 2019-02-25 at 12 17 24 pm" src="https://user-images.githubusercontent.com/32624665/53355725-a3eff380-38f7-11e9-9312-f50920fb2c97.png">


After:

![selection_026](https://user-images.githubusercontent.com/32624665/53185035-32006d00-35cc-11e9-9ff5-fbfaa25d554e.png)

