### PR TITLE
Removed trailing whitespace from normalized strings on format

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/StringUtils.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/StringUtils.java
@@ -39,14 +39,18 @@ public class StringUtils {
 	 * @return the result of normalize space of the given string.
 	 */
 	public static void normalizeSpace(String str, StringBuilder b) {
+		String space = "";
 		for (int i = 0; i < str.length(); ++i) {
 			char c = str.charAt(i);
 			if (Character.isWhitespace(c)) {
-				if (i <= 0 || Character.isWhitespace(str.charAt(i - 1)))
+				if (i == 0 || Character.isWhitespace(str.charAt(i - 1))) {
 					continue;
-				b.append(' ');
+				}
+				space = " ";
 				continue;
 			}
+			b.append(space);
+			space = "";
 			b.append(c);
 		}
 	}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/XMLBuilder.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/XMLBuilder.java
@@ -203,6 +203,7 @@ public class XMLBuilder {
 		if (isJoinCommentLines()) {
 			xml.append(" ");
 			xml.append(normalizeSpace(content));
+			xml.append(" ");
 		} else {
 			xml.append(content);
 		}

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaHoverExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaHoverExtensionsTest.java
@@ -28,7 +28,7 @@ public class XMLSchemaHoverExtensionsTest {
 				"<beans xmlns=\"http://www.springframework.org/schema/beans\" xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n"
 				+ "	<bea|n>";
 		assertHover(xml,
-				"Defines a single (usually named) bean. A bean definition may contain nested tags for constructor arguments, property values, lookup methods, and replaced methods. Mixing constructor injection and setter injection on the same bean is explicitly supported. ",
+				"Defines a single (usually named) bean. A bean definition may contain nested tags for constructor arguments, property values, lookup methods, and replaced methods. Mixing constructor injection and setter injection on the same bean is explicitly supported.",
 				2);
 
 	};
@@ -39,7 +39,7 @@ public class XMLSchemaHoverExtensionsTest {
 				"<beans xmlns=\"http://www.springframework.org/schema/beans\" xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n"
 				+ "	<bean clas|s=>";
 		assertHover(xml,
-				"The fully qualified name of the bean's class, except if it serves only as a parent definition for child bean definitions. ",
+				"The fully qualified name of the bean's class, except if it serves only as a parent definition for child bean definitions.",
 				null);
 	};
 

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLFormatterTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLFormatterTest.java
@@ -287,7 +287,7 @@ public class XMLFormatterTest {
 		"line 2" + lineSeparator() + 
 		"line 3" + lineSeparator() + 
 		"]]> </a>";
-		String expected = "<a>" + lineSeparator() + "  <![CDATA[line 1 line 2 line 3 ]]>" + lineSeparator() + "</a>";
+		String expected = "<a>" + lineSeparator() + "  <![CDATA[line 1 line 2 line 3]]>" + lineSeparator() + "</a>";
 		XMLFormattingOptions formattingOptions = createDefaultFormattingOptions();
 		formattingOptions.setJoinCDATALines(true);
 		format(content, expected, formattingOptions);
@@ -353,7 +353,7 @@ public class XMLFormatterTest {
 		" Content" + lineSeparator() +
 		"</a> <!-- My Comment -->";
 		String expected = 
-		"<a>Content </a> <!-- My Comment -->" + lineSeparator() +
+		"<a>Content</a> <!-- My Comment -->" + lineSeparator() +
 		"";
 	
 		XMLFormattingOptions formattingOptions = createDefaultFormattingOptions();
@@ -397,7 +397,7 @@ public class XMLFormatterTest {
 		"  Content5" + lineSeparator() +
 		"</a>";
 		String expected = 
-		"<a>Content Content2 Content3 Content4 Content5 </a>";
+		"<a>Content Content2 Content3 Content4 Content5</a>";
 		
 	
 		XMLFormattingOptions formattingOptions = createDefaultFormattingOptions();
@@ -515,8 +515,8 @@ public class XMLFormatterTest {
 		" </b>" + lineSeparator() +
 		"</a>";
 		String expected = 
-		"<a>Content " + lineSeparator() +
-		"  <b>Content2 Content3 </b>" + lineSeparator() +
+		"<a>Content" + lineSeparator() +
+		"  <b>Content2 Content3</b>" + lineSeparator() +
 		"</a>";
 		
 		XMLFormattingOptions formattingOptions = createDefaultFormattingOptions();
@@ -587,7 +587,7 @@ public class XMLFormatterTest {
 		String content = 
 		"<a> content </a>";
 		String expected = 
-		"<a>content </a>";
+		"<a>content</a>";
 		
 		XMLFormattingOptions formattingOptions = createDefaultFormattingOptions();
 		formattingOptions.setJoinContentLines(true);
@@ -601,7 +601,7 @@ public class XMLFormatterTest {
 		" Content" + lineSeparator() +
 		"</a>";
 		String expected = 
-		"<a>Content </a>";
+		"<a>Content</a>";
 		
 		XMLFormattingOptions formattingOptions = createDefaultFormattingOptions();
 		formattingOptions.setJoinContentLines(true);


### PR DESCRIPTION
eg:
```xml
 <a> Content </a>
```

Before changes:
```xml
 <a>Content </a>
```

After changes:
```xml
 <a>Content</a>
```