### PR TITLE
Fixed EOF Error

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
@@ -47,7 +47,7 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 	InvalidCommentStart, LessthanInAttValue, MarkupEntityMismatch, MarkupNotRecognizedInContent,
 	NameRequiredInReference, OpenQuoteExpected, PITargetRequired, PseudoAttrNameExpected, QuoteRequiredInXMLDecl,
 	SDDeclInvalid, SpaceRequiredBeforeEncodingInXMLDecl, SpaceRequiredBeforeStandalone, SpaceRequiredInPI,
-	VersionInfoRequired, VersionNotSupported, XMLDeclUnterminated, CustomETag; // https://wiki.xmldation.com/Support/Validator/EqRequiredInAttribute
+	VersionInfoRequired, VersionNotSupported, XMLDeclUnterminated, CustomETag, PrematureEOF; // https://wiki.xmldation.com/Support/Validator/EqRequiredInAttribute
 
 	private final String code;
 
@@ -173,6 +173,7 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 			int start = selectCurrentTagOffset(offset, document) + 1;
 			int end = offset + 1;
 			return XMLPositionUtility.createRange(start, end, document);
+		case PrematureEOF:
 		case XMLDeclUnterminated:
 			break;
 		default:

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/diagnostics/AbstractLSPErrorReporter.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/diagnostics/AbstractLSPErrorReporter.java
@@ -77,8 +77,13 @@ public abstract class AbstractLSPErrorReporter extends XMLErrorReporter {
 			message = str.toString();
 		}
 
+		Range adjustedRange = internalToLSPRange(location, key, arguments, xmlDocument);
+
+		if(adjustedRange == null) {
+			return null;
+		}
 		// Fill diagnostic
-		diagnostics.add(new Diagnostic(internalToLSPRange(location, key, arguments, xmlDocument), message,
+		diagnostics.add(new Diagnostic(adjustedRange, message,
 				toLSPSeverity(severity), source, key));
 
 		if (severity == SEVERITY_FATAL_ERROR && !fContinueAfterFatalError) {
@@ -126,6 +131,10 @@ public abstract class AbstractLSPErrorReporter extends XMLErrorReporter {
 		}
 		int startOffset = location.getCharacterOffset() - 1;
 		int endOffset = location.getCharacterOffset() - 1;
+
+		if(startOffset < 0 || endOffset < 0) {
+			return null;
+		}
 
 		// Create LSP range
 		Position start = toLSPPosition(startOffset, location, document.getTextDocument());

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/XMLAssert.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/XMLAssert.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.lsp4xml;
 
+import static org.junit.Assert.assertTrue;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -280,7 +282,10 @@ public class XMLAssert {
 
 		List<Diagnostic> actual = xmlLanguageService.doDiagnostics(xmlDocument, () -> {
 		}, settings.getValidation());
-		
+		if(expected == null) {
+			assertTrue(actual.isEmpty());
+			return;
+		}
 		assertDiagnostics(actual, Arrays.asList(expected), filter);
 	}
 

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
@@ -28,6 +28,18 @@ import org.junit.Test;
 public class XMLSchemaDiagnosticsTest {
 
 	@Test
+	public void prematureEOFNoErrorReported() throws Exception {
+		String xml = " ";
+		testDiagnosticsFor(xml);
+	}
+
+	@Test
+	public void prematureEOFWithPrologNoErrorReported() throws Exception {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?> ";
+		testDiagnosticsFor(xml);
+	}
+
+	@Test
 	public void cvc_complex_type_2_3() throws Exception {
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
 				"<beans xmlns=\"http://www.springframework.org/schema/beans\" xsi:schemaLocation=\"http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\r\n"


### PR DESCRIPTION
Fixes #157

The most common ocurrences of this error are
when the document is empty or there is just the
xml prolog (`<?xml ... ?>`). All errors that give negative values
will be ignored for now.

Signed-off-by: Nikolas <nikolaskomonen@gmail.com>