### PR TITLE
Completion for elements considers modelGroup of a complex type.

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/model/CMDocument.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/model/CMDocument.java
@@ -10,7 +10,7 @@
  */
 package org.eclipse.lsp4xml.extensions.contentmodel.model;
 
-import java.util.Collection;
+import java.util.List;
 
 import org.eclipse.lsp4xml.dom.DOMElement;
 
@@ -20,8 +20,8 @@ import org.eclipse.lsp4xml.dom.DOMElement;
  */
 public interface CMDocument {
 
-	Collection<CMElementDeclaration> getElements();
-	
+	List<CMElementDeclaration> getElements();
+
 	/**
 	 * Returns the declared element which matches the given XML element and null
 	 * otherwise.

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/model/CMElementDeclaration.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/model/CMElementDeclaration.java
@@ -11,6 +11,7 @@
 package org.eclipse.lsp4xml.extensions.contentmodel.model;
 
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Content model element which abstracts element declaration from a given
@@ -57,7 +58,7 @@ public interface CMElementDeclaration {
 	 * 
 	 * @return the children declared element of this declared element.
 	 */
-	Collection<CMElementDeclaration> getElements();
+	List<CMElementDeclaration> getElements();
 
 	/**
 	 * Returns the declared element which matches the given XML tag name / namespace

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/ContentModelCompletionParticipant.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/ContentModelCompletionParticipant.java
@@ -10,8 +10,17 @@
  */
 package org.eclipse.lsp4xml.extensions.contentmodel.participants;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
+import org.apache.xerces.impl.xs.XSWildcardDecl;
+import org.apache.xerces.xs.XSConstants;
+import org.apache.xerces.xs.XSElementDeclaration;
+import org.apache.xerces.xs.XSModelGroup;
+import org.apache.xerces.xs.XSObjectList;
+import org.apache.xerces.xs.XSParticle;
+import org.apache.xerces.xs.XSTerm;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.InsertTextFormat;
@@ -25,8 +34,12 @@ import org.eclipse.lsp4xml.extensions.contentmodel.model.CMDocument;
 import org.eclipse.lsp4xml.extensions.contentmodel.model.CMElementDeclaration;
 import org.eclipse.lsp4xml.extensions.contentmodel.model.ContentModelManager;
 import org.eclipse.lsp4xml.extensions.contentmodel.utils.XMLGenerator;
+import org.eclipse.lsp4xml.extensions.dtd.contentmodel.CMDTDElementDeclaration;
+import org.eclipse.lsp4xml.extensions.xsd.contentmodel.CMXSDDocument;
+import org.eclipse.lsp4xml.extensions.xsd.contentmodel.CMXSDElementDeclaration;
 import org.eclipse.lsp4xml.services.AttributeCompletionItem;
 import org.eclipse.lsp4xml.services.extensions.CompletionParticipantAdapter;
+import org.eclipse.lsp4xml.services.extensions.CompletionSortTextHelper;
 import org.eclipse.lsp4xml.services.extensions.ICompletionRequest;
 import org.eclipse.lsp4xml.services.extensions.ICompletionResponse;
 import org.eclipse.lsp4xml.settings.SharedSettings;
@@ -50,7 +63,7 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 				// XML Schema is done with pattern and not with XML root element)
 				CMDocument cmDocument = contentModelManager.findCMDocument(document, null);
 				if (cmDocument != null) {
-					fillWithChildrenElementDeclaration(null, cmDocument.getElements(), null, false, request, response);
+					fillWithChildrenElementDeclaration(null, cmDocument, null, false, request, response);
 				}
 				return;
 			}
@@ -59,9 +72,11 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 			CMElementDeclaration cmElement = contentModelManager.findCMElement(parentElement);
 			String defaultPrefix = null;
 			if (cmElement != null) {
+				response.addCompletionItem(null, true); //Set a fake item to prevent existing elements as completion items
 				defaultPrefix = parentElement.getPrefix();
-				fillWithChildrenElementDeclaration(parentElement, cmElement.getElements(), defaultPrefix, false,
+				fillWithChildrenElementDeclaration(parentElement, cmElement, defaultPrefix, false,
 						request, response);
+				return;
 			}
 			if (parentElement.isDocumentElement()) {
 				// root document element
@@ -73,7 +88,7 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 					String namespaceURI = parentElement.getNamespaceURI(prefix);
 					CMDocument cmDocument = contentModelManager.findCMDocument(parentElement, namespaceURI);
 					if (cmDocument != null) {
-						fillWithChildrenElementDeclaration(parentElement, cmDocument.getElements(), prefix, true,
+						fillWithChildrenElementDeclaration(parentElement, cmDocument, prefix, true,
 								request, response);
 					}
 				}
@@ -83,7 +98,7 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 			CMElementDeclaration cmInternalElement = contentModelManager.findInternalCMElement(parentElement);
 			if (cmInternalElement != null) {
 				defaultPrefix = parentElement.getPrefix();
-				fillWithChildrenElementDeclaration(parentElement, cmInternalElement.getElements(), defaultPrefix, false,
+				fillWithChildrenElementDeclaration(parentElement, cmInternalElement, defaultPrefix, false,
 						request, response);
 			}
 		} catch (CacheResourceDownloadingException e) {
@@ -91,25 +106,383 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 		}
 	}
 
-	private void fillWithChildrenElementDeclaration(DOMElement element, Collection<CMElementDeclaration> cmElements,
+	private void fillWithChildrenElementDeclaration(DOMElement element, CMElementDeclaration parentCMElement,
 			String p, boolean forceUseOfPrefix, ICompletionRequest request, ICompletionResponse response)
 			throws BadLocationException {
-		XMLGenerator generator = request.getXMLGenerator();
-		for (CMElementDeclaration child : cmElements) {
-			String prefix = forceUseOfPrefix ? p : (element != null ? element.getPrefix(child.getNamespace()) : null);
-			String label = child.getName(prefix);
-			CompletionItem item = new CompletionItem(label);
-			item.setFilterText(request.getFilterForStartTagName(label));
-			item.setKind(CompletionItemKind.Property);
-			String documentation = child.getDocumentation();
-			if (documentation != null) {
-				item.setDetail(documentation);
-			}
-			String xml = generator.generate(child, prefix);
-			item.setTextEdit(new TextEdit(request.getReplaceRange(), xml));
-			item.setInsertTextFormat(InsertTextFormat.Snippet);
-			response.addCompletionItem(item, true);
+		if(parentCMElement instanceof CMXSDElementDeclaration) {
+			CMXSDElementDeclaration parentCMXSDElement = (CMXSDElementDeclaration) parentCMElement;
+			
+			List<CMElementDeclaration> finalItems = getNextValidDeclsFromModelGroup(element, parentCMXSDElement, parentCMXSDElement.getParticle(), p, forceUseOfPrefix, request, response);
+			
+			CompletionSortTextHelper sort = new CompletionSortTextHelper(CompletionItemKind.Property);
+			createElementCompletionItems(element, finalItems, p, request, response, sort, forceUseOfPrefix);
 		}
+		else if(parentCMElement instanceof CMDTDElementDeclaration) {
+			CompletionSortTextHelper sort = new CompletionSortTextHelper(CompletionItemKind.Property);
+
+			createElementCompletionItems(element, parentCMElement.getElements(), p, request, response, sort, forceUseOfPrefix);
+		}
+	}
+
+	private void fillWithChildrenElementDeclaration(DOMElement element, CMDocument cmDocument,
+			String p, boolean forceUseOfPrefix, ICompletionRequest request, ICompletionResponse response)
+			throws BadLocationException {
+		CompletionSortTextHelper sort = new CompletionSortTextHelper(CompletionItemKind.Property);
+		createElementCompletionItems(element, cmDocument.getElements(), p, request, response, sort, forceUseOfPrefix);
+
+	}
+
+	private List<CMElementDeclaration> getNextValidDeclsFromModelGroup(DOMElement element, CMXSDElementDeclaration parentCMElement, XSParticle modelGroupParticle,
+	String prefix, boolean forceUseOfPrefix, ICompletionRequest request, ICompletionResponse response)
+			throws BadLocationException {
+
+		if(parentCMElement == null) {
+			return null;
+		}
+
+		if(modelGroupParticle.getTerm().getType() != XSConstants.MODEL_GROUP) {
+			return null;
+		}
+
+		XSModelGroup modelGroup = (XSModelGroup) modelGroupParticle.getTerm();
+
+		List<DOMElement> domElements = null;
+		if(element != null) {
+			domElements = element.getChildElements();
+		} 
+		
+		int offset = request.getOffset();
+
+		short modelGroupType = modelGroup.getCompositor();
+		switch(modelGroupType) {
+			case -1:
+				return null;
+			case XSModelGroup.COMPOSITOR_CHOICE:
+			case XSModelGroup.COMPOSITOR_ALL: {
+				if(modelGroupType == XSModelGroup.COMPOSITOR_CHOICE) {
+					
+					
+					if(!modelGroupParticle.getMaxOccursUnbounded()) {
+						int elementCounter = 0;
+						List<CMElementDeclaration> zz = new ArrayList<CMElementDeclaration>();
+						parentCMElement.collectElementsDeclaration(modelGroup, zz);
+						for (DOMElement domElement : domElements) {
+							for (CMElementDeclaration cmElement : zz) {
+								if(domElement.getLocalName().equals(cmElement.getName())) {
+									elementCounter++;
+									if(elementCounter >= modelGroupParticle.getMaxOccurs()) {
+										return null;
+									}
+								}
+							}
+						}
+					}
+				}
+
+				List<CMElementDeclaration> validElements = new ArrayList<CMElementDeclaration>();
+				
+				
+				XSObjectList particles = modelGroup.getParticles();
+				int particleSize = particles.getLength();
+				int particleIndex = 0;
+				while(particleIndex < particleSize) { // All possible element declarations
+					List<CMElementDeclaration> currentDeclElements = new ArrayList<CMElementDeclaration>();
+					XSParticle particle = (XSParticle) particles.get(particleIndex);
+					particleIndex++;
+					XSTerm term = particle.getTerm();
+					if(term.getType() == XSConstants.ELEMENT_DECLARATION) {
+						//populates list with all possible options for this declaration
+						//considers if it is a reference/substitution groups.
+						parentCMElement.getDocument().collectElement((XSElementDeclaration) term, currentDeclElements);
+					}
+					else if(term.getType() == XSConstants.MODEL_GROUP){
+						currentDeclElements.addAll(getNextValidDeclsFromModelGroup(element, parentCMElement, particle, prefix, forceUseOfPrefix, request, response));
+					}
+					else if(term.getType() == XSConstants.WILDCARD) {
+							
+						DOMDocument domDocument = element.getOwnerDocument();
+						DOMElement rootElement = domDocument.getDocumentElement();
+						collectElementsFromWildcard(term, currentDeclElements, rootElement, prefix, request);
+					}
+
+					boolean addDecl = true;
+					for (DOMElement childDom: domElements) {
+						int matchingDeclIndex = getElementOffsetInList(currentDeclElements, childDom);
+						if(matchingDeclIndex >= 0) {
+							//CMElementDeclaration matchingDecl = currentDeclElements.get(matchingDeclIndex);
+							if(modelGroupType == XSModelGroup.COMPOSITOR_CHOICE) { // choice only allows for one of it's options
+								boolean isUnderMaxOccurs = particle.getMaxOccurs() > element.getNumberOfChildElementsWithTagName(childDom.getTagName());
+								if(modelGroupParticle.getMaxOccursUnbounded() || isUnderMaxOccurs) {
+									// This choice is allowed again since max occurs has not yet been reached
+									CMElementDeclaration singleCMElement = currentDeclElements.get(getElementOffsetInList(currentDeclElements, childDom));
+									currentDeclElements.clear();
+									currentDeclElements.add(singleCMElement);
+									break;
+								}
+							}
+							addDecl = false; // already exists, don't give as option.
+							break;
+						}
+					}
+					if(addDecl) {
+						validElements.addAll(currentDeclElements);
+					}
+				}
+				return validElements;
+			}
+			
+			case XSModelGroup.COMPOSITOR_SEQUENCE: {
+				List<CMElementDeclaration> validElements = getNextValidElementInSequence(element, parentCMElement, modelGroup, prefix, forceUseOfPrefix, request, response, offset);
+				if(validElements == null) {
+					break;
+				}
+				return validElements;
+			}
+		}
+		return null;
+	}
+
+
+	
+	private void collectElementsFromWildcard(XSTerm term , Collection<CMElementDeclaration> elements, DOMElement rootElement, String prefix, ICompletionRequest request) {
+		XSWildcardDecl wc = (XSWildcardDecl) term;
+		Collection<String> prefixes = rootElement.getAllPrefixes();
+		boolean useOnlyOtherNamespaces = false; // ##other
+		for (String wildCardNamespace : wc.fNamespaceList) {
+			if(wildCardNamespace == null ) {
+				continue;
+			}
+			if(wildCardNamespace.equals("##other")) {
+				useOnlyOtherNamespaces = true;
+				continue;
+			}
+			for (String p : prefixes) {
+				if (prefix != null && p.equals(prefix) && useOnlyOtherNamespaces) {
+					continue;
+				}
+				else {
+					String namespaceURI = rootElement.getNamespaceURI(p);
+					ContentModelManager contentModelManager = request.getComponent(ContentModelManager.class);
+					CMDocument cmDocument = contentModelManager.findCMDocument(rootElement, namespaceURI);
+					if(cmDocument != null) {
+						elements.addAll(cmDocument.getElements());
+					}
+				}
+			}
+		}
+	}
+	
+	private List<CMElementDeclaration> getNextValidElementInSequence(DOMElement parentDOMElement, CMXSDElementDeclaration parentCMElement, XSTerm termModelGroup,
+	String prefix, boolean forceUseOfPrefix, ICompletionRequest request, ICompletionResponse response, int offset) throws BadLocationException {
+		CMXSDDocument cmXSDDocument = parentCMElement.getDocument();
+		
+		if(termModelGroup.getType() != XSConstants.MODEL_GROUP) {
+			return null;
+		}
+		XSModelGroup modelGroup = (XSModelGroup) termModelGroup;
+		// In the case of multiple unique optional decls and the (eg 3rd) one exists
+		// and completion is attempted before it, we queue all previous optional declarations
+		// in case we find one that exists later, meaning we can discard all previous to it
+		// since the most recent existing optional declaration is the lower bound.
+		List<CMElementDeclaration> optionalElementDeclarations = new ArrayList<>();
+		List<CMElementDeclaration> allValidDeclarations = new ArrayList<>();
+		List<DOMElement> domElements = parentDOMElement != null ? parentDOMElement.getChildElements() : null;
+		boolean domElementsHasValues = domElements != null && !domElements.isEmpty();
+		int handledExistingElements = 0; // used as an index to point to the next unhandled dom element
+		int iDecl;
+		XSObjectList particles = modelGroup.getParticles();
+		for(iDecl = 0; iDecl < particles.size(); iDecl++) {
+			XSParticle particle = (XSParticle) particles.get(iDecl);
+			boolean isOptional = particle.getMinOccurs() == 0; //TODO: check if elementDecl is nillable
+			XSTerm term = particle.getTerm();
+			List<CMElementDeclaration> currentElementDeclarations = new ArrayList<>();
+			if(term.getType() == XSConstants.ELEMENT_DECLARATION) {
+				//populates list with all possible options for this declaration
+				//considers if it is a reference/substitution groups.
+				cmXSDDocument.collectElement((XSElementDeclaration) term, currentElementDeclarations);
+			}
+			else if(term.getType() == XSConstants.MODEL_GROUP){
+				List<CMElementDeclaration> l = getNextValidDeclsFromModelGroup(parentDOMElement, parentCMElement, particle, prefix, forceUseOfPrefix, request, response);
+				if(l == null) {
+					continue;
+				}
+				currentElementDeclarations.addAll(l);
+			}
+			else if(term.getType() == XSConstants.WILDCARD) {
+				DOMDocument domDocument = parentDOMElement.getOwnerDocument();
+				DOMElement rootElement = domDocument.getDocumentElement();
+				collectElementsFromWildcard(term, currentElementDeclarations, rootElement, prefix, request);
+			}
+			
+			if(domElements == null || handledExistingElements > domElements.size() - 1) { // Seen all xml document elements, no more child elements after this.
+				if(!isOptional) { 
+					allValidDeclarations.addAll(optionalElementDeclarations);
+					allValidDeclarations.addAll(currentElementDeclarations);
+					return allValidDeclarations;
+				}
+				// If this point is reached, then this element declaration was optional
+				// so continue to the next declaration and add those too if valid.
+				addOptionalElementDecls(optionalElementDeclarations, currentElementDeclarations);
+				continue;
+			}
+			
+			if(domElementsHasValues){
+				DOMElement domElement = domElements.get(handledExistingElements);
+				boolean canHaveMultipleOccurrences = particle.getMaxOccursUnbounded() || particle.getMaxOccurs() > parentDOMElement.getNumberOfSameSurroundingElements(domElement);
+				boolean declsContainElement = doElementDeclsContainElement(currentElementDeclarations, domElement);
+				if(offset < domElement.getStart()) { // This element is after the completion offset position
+					if(declsContainElement) { // The element after offset is already the next valid decl
+						allValidDeclarations.addAll(optionalElementDeclarations);
+						if(canHaveMultipleOccurrences) {
+							allValidDeclarations.addAll(currentElementDeclarations);
+						}
+						return allValidDeclarations;
+					}
+					
+					if(!isOptional) { // element decl is not optional, search is done.
+						allValidDeclarations.addAll(optionalElementDeclarations);
+						allValidDeclarations.addAll(currentElementDeclarations); // The element after the offset is not valid, so give the correct element
+						return allValidDeclarations;
+					}
+					addOptionalElementDecls(optionalElementDeclarations, currentElementDeclarations);
+					continue; // go to next element decl, this one was optional 
+				}
+				else if(!declsContainElement || canHaveMultipleOccurrences) { // at this point the offset is after the dom element
+					if(!isOptional) { //element decl is not optional
+						allValidDeclarations.addAll(optionalElementDeclarations);
+						allValidDeclarations.addAll(currentElementDeclarations);
+						return allValidDeclarations;
+					}
+					
+					if(!declsContainElement) {
+						//This optional element decl is missing and the current element is not it
+						addOptionalElementDecls(optionalElementDeclarations, currentElementDeclarations);
+					}
+					else {
+						//all previous optional elements are now invalid since this one exists.
+						optionalElementDeclarations.clear();
+						addOptionalElementDecls(optionalElementDeclarations, currentElementDeclarations);
+						//Go to next different xml element (skips all same named optional elements)
+						int elementAfterOffsetIndex = skipOverSameElements(domElements, handledExistingElements, offset);
+						if(elementAfterOffsetIndex > domElements.size() - 1) { // all elements after were the same 
+							continue;
+						}
+						DOMElement elementAfterOffset = domElements.get(elementAfterOffsetIndex);
+
+						//edge case of completion between the same optional element
+						if(domElement.getTagName().equals(elementAfterOffset.getTagName())) {
+							return optionalElementDeclarations;
+							
+						}
+						// the next different element was reached
+						handledExistingElements = elementAfterOffsetIndex;
+					}
+					
+				}
+				else { // Existing element decl already exists in the document.
+					handledExistingElements++;
+					// Since we found a non-optional element decl, we know previous optional decls are invalid.
+					optionalElementDeclarations.clear();
+					
+				}
+			}
+		}
+		allValidDeclarations.addAll(optionalElementDeclarations);
+		return allValidDeclarations;
+	}
+
+
+	public boolean doElementDeclsContainElement(List<CMElementDeclaration> elements, DOMElement element) {
+		return getElementOffsetInList(elements, element) != -1;
+	}
+
+	public int getElementOffsetInList(List<CMElementDeclaration> elements, DOMElement element) {
+		int i;
+		for(i = 0; i < elements.size(); i++) {
+			CMElementDeclaration cmElement = elements.get(i);
+			if(cmElement.getName().equals(element.getTagName())) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	public void addOptionalElementDecls(List<CMElementDeclaration> addTo, List<CMElementDeclaration> addFrom) {
+		
+		for (CMElementDeclaration from : addFrom) {
+			if(from instanceof CMXSDElementDeclaration) {
+				CMXSDElementDeclaration xsdFrom = (CMXSDElementDeclaration) from;
+				xsdFrom.setOptional(true);
+				addTo.add(xsdFrom);
+			}
+		}
+	}
+
+	/**
+	 * Will go to the first element that has a different name from the initialElement.
+	 * 
+	 * If the stop offset is reached the element after it is returned. There is
+	 * a chance this is an element with the same name as the inital element.
+	 */
+	public int skipOverSameElements(List<DOMElement> domElements, int initialElementIndex, int stopOffset) {
+		DOMElement initalElement = domElements.get(initialElementIndex);
+		String initialElementName = initalElement.getTagName();
+		int size = domElements.size();
+		int index = initialElementIndex + 1;
+		while(index < size) {
+			DOMElement currentElement = domElements.get(index);
+			if(stopOffset < currentElement.getStart()) {
+				return index;
+			}
+			if(!initialElementName.equals(currentElement.getTagName())) {
+				return index;
+			}
+			index++;
+		}
+		return index;
+	}
+
+	public void createElementCompletionItems(DOMElement element, List<CMElementDeclaration> children, String prefix,
+	ICompletionRequest request, ICompletionResponse response, CompletionSortTextHelper sort, boolean forceUseOfPrefix) 
+			throws BadLocationException {
+		
+		for (CMElementDeclaration child : children) {
+			createElementCompletionItem(element, child, prefix, request, response, sort, forceUseOfPrefix);
+		}
+	}
+	
+	public void createElementCompletionItem(DOMElement element, CMElementDeclaration child, String prefix,
+			ICompletionRequest request, ICompletionResponse response, CompletionSortTextHelper sort, boolean forceUseOfPrefix) 
+			throws BadLocationException {
+		
+		prefix = forceUseOfPrefix ? prefix : (element != null ? element.getPrefix(child.getNamespace()) : null);
+		String label = child.getName(prefix);
+		if(response.hasSeen(label)) {
+			return;
+		}
+		XMLGenerator generator = request.getXMLGenerator();
+		CompletionItem item = new CompletionItem(label);
+		item.setFilterText(request.getFilterForStartTagName(label));
+		item.setKind(CompletionItemKind.Property);
+		item.setSortText(sort.next());
+		if(child instanceof CMXSDElementDeclaration) {
+			CMXSDElementDeclaration xsdDecl = (CMXSDElementDeclaration) child;
+			if(xsdDecl.isOptional) {
+				String completionPrefix = CompletionSortTextHelper.getSortText(CompletionItemKind.Property);
+				item.setDetail("optional");
+				item.setSortText(completionPrefix + "b");
+			}
+		}
+		
+		String documentation = child.getDocumentation();
+		if (documentation != null) {
+			item.setDocumentation(documentation);
+		}
+		String xml = generator.generate(child, prefix);
+		item.setTextEdit(new TextEdit(request.getReplaceRange(), xml));
+		InsertTextFormat textFormat = request.getCompletionSettings().isCompletionSnippetsSupported() ? InsertTextFormat.Snippet : InsertTextFormat.PlainText;
+		item.setInsertTextFormat(textFormat);
+		response.addCompletionItemAsSeen(item);
 	}
 
 	@Override
@@ -155,7 +528,7 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 				if (documentation != null) {
 					item.setDetail(documentation);
 				}
-				response.addCompletionAttribute(item);
+				response.addCompletionItemAsSeen(item);
 			}
 		}
 	}
@@ -190,7 +563,7 @@ public class ContentModelCompletionParticipant extends CompletionParticipantAdap
 					CompletionItem item = new CompletionItem();
 					item.setLabel(value);
 					item.setKind(CompletionItemKind.Value);
-					response.addCompletionAttribute(item);
+					response.addCompletionItemAsSeen(item);
 				});
 			}
 		}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/dtd/contentmodel/CMDTDDocument.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/dtd/contentmodel/CMDTDDocument.java
@@ -43,7 +43,7 @@ public class CMDTDDocument extends XMLDTDLoader implements CMDocument {
 	private List<String> hierachies;
 
 	@Override
-	public Collection<CMElementDeclaration> getElements() {
+	public List<CMElementDeclaration> getElements() {
 		if (elements == null) {
 			elements = new ArrayList<>();
 			int index = grammar.getFirstElementDeclIndex();

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/dtd/contentmodel/CMDTDElementDeclaration.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/dtd/contentmodel/CMDTDElementDeclaration.java
@@ -54,7 +54,7 @@ public class CMDTDElementDeclaration extends XMLElementDecl implements CMElement
 	}
 
 	@Override
-	public Collection<CMElementDeclaration> getElements() {
+	public List<CMElementDeclaration> getElements() {
 		if (elements == null) {
 			elements = new ArrayList<>();
 			document.collectElementsDeclaration(getName(), elements);

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/references/participants/XMLReferencesCompletionParticipant.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/references/participants/XMLReferencesCompletionParticipant.java
@@ -38,7 +38,7 @@ public class XMLReferencesCompletionParticipant extends CompletionParticipantAda
 				CompletionItem item = new CompletionItem();
 				item.setLabel(label);
 				String insertText = label;
-				item.setKind(CompletionItemKind.Property);
+				item.setKind(CompletionItemKind.Text);
 				item.setDocumentation(Either.forLeft(label));
 				item.setFilterText(insertText);
 				item.setTextEdit(new TextEdit(range, insertText));

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/contentmodel/CMXSDElementDeclaration.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/contentmodel/CMXSDElementDeclaration.java
@@ -210,11 +210,12 @@ public class CMXSDElementDeclaration implements CMElementDeclaration {
 		case XSConstants.WILDCARD:
 			// XSWildcard wildcard = (XSWildcard) term;
 			// ex : xsd:any
-			document.getElements().forEach(e -> {
-				if (!elements.contains(e)) {
-					elements.add(e);
-				}
-			});
+			// document.getElements().forEach(e -> {
+			// 	if (!elements.contains(e)) {
+			// 		elements.add(e);
+			// 	}
+			// });
+			
 			break;
 		case XSConstants.MODEL_GROUP:
 			XSObjectList particles = ((XSModelGroup) term).getParticles();

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsi/XSISchemaModel.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsi/XSISchemaModel.java
@@ -87,7 +87,7 @@ public class XSISchemaModel {
 
 		boolean isSnippetsSupported = request.getCompletionSettings().isCompletionSnippetsSupported();
 		if(inRootElement) {
-			if(!hasAttribute(elementAtOffset, "xmlns") && !response.hasAttribute("xmlns")) { // "xmlns" completion
+			if(!hasAttribute(elementAtOffset, "xmlns") && !response.hasSeen("xmlns")) { // "xmlns" completion
 				createCompletionItem("xmlns", isSnippetsSupported, generateValue, editRange, null, null, null, response, settings);
 			}
 			if(document.hasSchemaInstancePrefix() == false) { // "xmlns:xsi" completion
@@ -196,7 +196,7 @@ public class XSISchemaModel {
 			item = new CompletionItem();
 			item.setLabel(option);
 			item.setFilterText(currentQuotation + option + currentQuotation);
-			item.setKind(CompletionItemKind.Enum);
+			item.setKind(CompletionItemKind.Value);
 			item.setTextEdit(new TextEdit(editRange, optionWithQuotes));
 			response.addCompletionItem(item);
 		}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/CompletionRequest.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/CompletionRequest.java
@@ -50,7 +50,11 @@ class CompletionRequest extends AbstractPositionRequest implements ICompletionRe
 
 	@Override
 	protected DOMNode findNodeAt(DOMDocument xmlDocument, int offset) {
-		return xmlDocument.findNodeBefore(offset);
+		DOMNode node = xmlDocument.findNodeBefore(offset);
+		if(node.isClosed() && offset >= node.getEnd()) {
+			node = node.getParentNode();
+		}
+		return node;
 	}
 
 	@Override

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/CompletionResponse.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/CompletionResponse.java
@@ -33,8 +33,19 @@ class CompletionResponse extends CompletionList implements ICompletionResponse {
 	public void addCompletionItem(CompletionItem completionItem, boolean fromGrammar) {
 		if (fromGrammar) {
 			hasSomeItemFromGrammar = true;
+
+		}
+		if(completionItem == null) {
+			return;
 		}
 		addCompletionItem(completionItem);
+	}
+
+	/**
+	 * Indicates to not create anymore completion items.
+	 */
+	public void doNotCreateAnymoreItems() {
+		this.hasSomeItemFromGrammar = true;
 	}
 
 	@Override
@@ -48,15 +59,16 @@ class CompletionResponse extends CompletionList implements ICompletionResponse {
 	}
 
 	@Override
-	public boolean hasAttribute(String attribute) {
+	public boolean hasSeen(String label) {
 		/*
 		 * if (node != null && node.hasAttribute(attribute)) { return true; }
 		 */
-		return seenAttributes != null ? seenAttributes.contains(attribute) : false;
+		return seenAttributes != null ? seenAttributes.contains(label) : false;
 	}
 
 	@Override
-	public void addCompletionAttribute(CompletionItem completionItem) {
+	public void addCompletionItemAsSeen(CompletionItem completionItem) {
+		hasSomeItemFromGrammar = true;
 		if (seenAttributes == null) {
 			seenAttributes = new ArrayList<>();
 		}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLCompletions.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLCompletions.java
@@ -486,6 +486,14 @@ public class XMLCompletions {
 		}
 		DOMElement parentNode = completionRequest.getParentElement();
 		if (parentNode != null && !completionResponse.hasSomeItemFromGrammar()) {
+
+			/**
+			 * If no CompletionParticipants create a completion item then
+			 * this will create completions of existing elements. There is
+			 * a chance this is invalid based off of the schema.
+			 */
+
+
 			// no grammar, collect similar tags from the parent node
 			Set<String> seenElements = new HashSet<>();
 			if (parentNode != null && parentNode.isElement() && parentNode.hasChildNodes()) {
@@ -641,7 +649,7 @@ public class XMLCompletions {
 				beginProposal.setSortText("za");
 				beginProposal.setKind(CompletionItemKind.Snippet);
 				beginProposal.setInsertTextFormat(InsertTextFormat.Snippet);
-				response.addCompletionAttribute(beginProposal);
+				response.addCompletionItemAsSeen(beginProposal);
 
 				CompletionItem endProposal = new CompletionItem("#endregion");
 				endProposal.setKind(CompletionItemKind.Snippet);
@@ -649,7 +657,7 @@ public class XMLCompletions {
 				endProposal.setDocumentation("Folding Region End");
 				endProposal.setFilterText(match.group());
 				endProposal.setSortText("zb");
-				response.addCompletionAttribute(endProposal);
+				response.addCompletionItemAsSeen(endProposal);
 			}
 		} catch (BadLocationException e) {
 			LOGGER.log(Level.SEVERE, "While performing collectRegionCompletion", e);

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/CompletionSortTextHelper.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/CompletionSortTextHelper.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.lsp4xml.services.extensions;
+
+import org.eclipse.lsp4j.CompletionItemKind;
+
+/**
+ * CompletionSortText class to get sortText for CompletionItem's
+ */
+public class CompletionSortTextHelper {
+
+	private int i;
+	private final String base;
+
+	public CompletionSortTextHelper(CompletionItemKind kind) {
+		this.base = getSortText(kind);
+		i = 0;
+	}
+
+	public String next() {
+		i++;
+		return base + Integer.toString(i);
+	}
+
+	public static String getSortText(CompletionItemKind kind) {
+		switch (kind) {
+		case Variable:
+		case Property: // DOMElement
+		case Enum:
+		case EnumMember:
+		case Value:
+			return "aa";
+		default:
+			return "zz";
+		}
+	}
+
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/ICompletionResponse.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/ICompletionResponse.java
@@ -33,14 +33,14 @@ public interface ICompletionResponse {
 	 */
 	void addCompletionItem(CompletionItem completionItem);
 
-	boolean hasAttribute(String attribute);
+	boolean hasSeen(String label);
 
 	/**
 	 * Add completion attribute.
 	 * 
 	 * @param item
 	 */
-	void addCompletionAttribute(CompletionItem item);
+	void addCompletionItemAsSeen(CompletionItem item);
 
 	/**
 	 * Returns <code>true</code> if there are completion items coming from grammar

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/catalog/XMLCatalogExtensionTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/catalog/XMLCatalogExtensionTest.java
@@ -31,7 +31,7 @@ public class XMLCatalogExtensionTest {
 				"<catalog xmlns=\"urn:oasis:names:tc:entity:xmlns:xml:catalog\">\r\n" + //
 				"    |";
 
-		XMLAssert.testCompletionFor(xml, 16, c("public", "<public publicId=\"\" uri=\"\" />"));
+		XMLAssert.testCompletionFor(xml, 15, c("public", "<public publicId=\"\" uri=\"\" />"));
 	}
 
 	@Test

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
@@ -21,7 +21,6 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4xml.XMLAssert;
 import org.eclipse.lsp4xml.commons.BadLocationException;
 import org.eclipse.lsp4xml.services.XMLLanguageService;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -199,8 +198,17 @@ public class XMLSchemaCompletionExtensionsTest {
 				+ //
 				"  <ViewDefinitions>\r\n" + //
 				"    <View><|";
-		XMLAssert.testCompletionFor(xml, null, "src/test/resources/Format.xml", null, c("Name", "<Name></Name>"),
-				c("ViewSelectedBy", "<ViewSelectedBy></ViewSelectedBy>"));
+		XMLAssert.testCompletionFor(xml, null, "src/test/resources/Format.xml", null, c("Name", "<Name></Name>"));
+	}
+	
+	@Test
+	public void noNamespaceSchemaLocationCompletionAfterName() throws BadLocationException {
+		String xml = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n" + //
+				"<Configuration xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"xsd/Format.xsd\">\r\n"
+				+ //
+				"  <ViewDefinitions>\r\n" + //
+				"    <View><Name></Name><|";
+		XMLAssert.testCompletionFor(xml, null, "src/test/resources/Format.xml", null, c("ViewSelectedBy","<ViewSelectedBy></ViewSelectedBy>"));
 	}
 
 	@Test
@@ -210,7 +218,7 @@ public class XMLSchemaCompletionExtensionsTest {
 				+ " xsi:schemaLocation=\"http://invoice xsd/invoice.xsd \">\r\n" + //
 				"  <|";
 		XMLAssert.testCompletionFor(xml, null, "src/test/resources/invoice.xml", null, c("date", "<date></date>"),
-				c("number", "<number></number>"));
+				c("date", "<date></date>"));
 	}
 
 	@Test
@@ -500,6 +508,259 @@ public class XMLSchemaCompletionExtensionsTest {
 
 		XMLAssert.testCompletionFor(xml, 2, c("xsi:nil", "xsi:nil=\"true\""), c("xsi:type", "xsi:type=\"\""));
 	}
+
+
+	@Test
+	public void testXSDSequenceCompletion() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns=\"http://sequence\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:schemaLocation=\"http://sequence ../xsd/modelGroup/sequence.xsd\">\r\n" +
+			"  <e1></e1>\r\n" +
+			"  <e2></e2>\r\n" +
+			"  |\r\n" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", null, c("e3", "<e3></e3>"));
+	};
+
+	@Test
+	public void testXSDSequenceCompletion2() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns=\"http://sequence\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:schemaLocation=\"http://sequence ../xsd/modelGroup/sequence.xsd\">\r\n" +
+			"  <e1></e1>\r\n" +
+			"  <e2></e2>\r\n" +
+			"  |\r\n" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", null, c("e3", "<e3></e3>"), c("optional2", "<optional2></optional2>"), c("optional22", "<optional22></optional22>"));
+	};
+	
+	@Test
+	public void testXSDSequenceCompletion3() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns=\"http://sequence\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:schemaLocation=\"http://sequence ../xsd/modelGroup/sequence.xsd\">\r\n" +
+			"  <e1></e1>\r\n" +
+			"  <e2></e2>\r\n" +
+			"  |\r\n" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 5, c("e3", "<e3></e3>"), c("optional2", "<optional2></optional2>"), c("optional22", "<optional22></optional22>"));
+		// The added 2 completions are the start/end folding range completions
+	};
+	
+	@Test
+	public void testXSDSequenceCompletion4() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns=\"http://sequence\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:schemaLocation=\"http://sequence ../xsd/modelGroup/sequence.xsd\">\r\n" +
+			"  |\r\n" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 4, c("optional0", "<optional0></optional0>"), c("e1", "<e1></e1>"));
+	};
+	
+	@Test
+	public void testXSDSequenceCompletionMaxOccursAndNextRequired() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns=\"http://sequence\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:schemaLocation=\"http://sequence ../xsd/modelGroup/sequence.xsd\">\r\n" +
+			"  <optional0></optional0>\r\n" +
+			"  <optional0></optional0>\r\n" +
+			"  <optional0></optional0>\r\n" +
+			"  |\r\n" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 4, c("optional0", "<optional0></optional0>"), c("e1", "<e1></e1>"));
+	};
+	
+	@Test
+	public void testXSDSequenceCompletionMaxOccursInsideSameElement() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns=\"http://sequence\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:schemaLocation=\"http://sequence ../xsd/modelGroup/sequence.xsd\">\r\n" +
+			"  <optional0></optional0>\r\n" +
+			"  |\r\n" +
+			"  <optional0></optional0>\r\n" +	
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 3, c("optional0", "<optional0></optional0>"));
+	};
+
+	@Test
+	public void testXSDSequenceCompletionDidntReachMaxOccursAtEnd() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns=\"http://sequence\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:schemaLocation=\"http://sequence ../xsd/modelGroup/sequenceMaxOccurs.xsd\">\r\n" +
+			"  <e1></e1>\r\n" +
+			"  <e2></e2>\r\n" +
+			"  |" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 3, c("e2", "<e2></e2>"));
+	};
+
+	@Test
+	public void testXSDSequenceCompletionReachedMaxOccursAtEnd() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns=\"http://sequence\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:schemaLocation=\"http://sequence ../xsd/modelGroup/sequenceMaxOccurs.xsd\">\r\n" +
+			"  <e1></e1>\r\n" +
+			"  <e2></e2>\r\n" +
+			"  <e2></e2>\r\n" +
+			"  |" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 2);
+	};
+
+	@Test
+	public void testXSDSequenceCompletion5() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns=\"http://sequence\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:schemaLocation=\"http://sequence ../xsd/modelGroup/sequence.xsd\">\r\n" +
+			"  <optional0></optional0>\r\n" +
+			"  <e1></e1>\r\n" +
+			"  <optional1></optional1>\r\n" +
+			"  |\r\n" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 5, c("optional1", "<optional1></optional1>"), c("optional11", "<optional11></optional11>"), c("e2", "<e2></e2>"));
+	};
+	
+	@Test
+	public void testXSDSequenceCompletionNoMoreCompletions() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns=\"http://sequence\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:schemaLocation=\"http://sequence ../xsd/modelGroup/sequence.xsd\">\r\n" +
+			"  <optional0></optional0>\r\n" +
+			"  <e1></e1>\r\n" +
+			"  <e2></e2>\r\n" +
+			"  <e3></e3>\r\n" +
+			"  <optional3></optional3>\r\n" +
+			"  |\r\n" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 2);
+	};
+	
+	@Test
+	public void testXSDSequenceSubstitutionGroup() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:noNamespaceSchemaLocation=\"../xsd/modelGroup/sequenceSubstitutionGroup.xsd\">\r\n" +
+			"  <optional0></optional0>\r\n" +
+			"  <e1></e1>\r\n" +
+			"  |\r\n" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 6,  c("optional1", "<optional1></optional1>"), c("substituteElement", "<substituteElement></substituteElement>") , c("substituted1", "<substituted1></substituted1>"),  c("substituted2", "<substituted2></substituted2>"));
+	};
+	
+	@Test
+	public void testXSDChoice() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:noNamespaceSchemaLocation=\"../xsd/modelGroup/choice.xsd\">\r\n" +
+			"  |\r\n" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 5,  c("e1", "<e1></e1>"), c("e2", "<e2></e2>"), c("e3", "<e3></e3>") );
+	};
+
+	@Test
+	public void testXSDChoiceOneAlreadyExists() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:noNamespaceSchemaLocation=\"../xsd/modelGroup/choice.xsd\">\r\n" +
+			"  <e3></e3>\r\n" +
+			"  |\r\n" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 2);
+	};
+	
+	@Test
+	public void testXSDChoiceWithMaxOccurs() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:noNamespaceSchemaLocation=\"../xsd/modelGroup/choiceMaxOccurs.xsd\">\r\n" +
+			"  <e3></e3>\r\n" +
+			"  <e3></e3>\r\n" +
+			"  |\r\n" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 4, c("e1", "<e1></e1>"), c("e2", "<e2></e2>"));
+	};
+	
+	@Test
+	public void testXSDChoiceWithMaxOccursOnlyInChoice() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:noNamespaceSchemaLocation=\"../xsd/modelGroup/choiceMaxOccursOnlyChoice.xsd\">\r\n" +
+			"  <e3></e3>\r\n" +
+			"  <e2></e2>\r\n" +
+			"  |\r\n" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 3, c("e1", "<e1></e1>"));
+	};
+	
+	@Test
+	public void testXSDChoiceWithMaxOccursOnlyInChoiceWithMultipleMissing() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:noNamespaceSchemaLocation=\"../xsd/modelGroup/choiceMaxOccursOnlyChoice.xsd\">\r\n" +
+			"  <e3></e3>\r\n" +
+			"  |\r\n" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 4, c("e1", "<e1></e1>"), c("e2", "<e2></e2>"));
+	};
+	
+	@Test
+	public void testXSDAll() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:noNamespaceSchemaLocation=\"../xsd/modelGroup/all.xsd\">\r\n" +
+			"  |\r\n" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 5,  c("e1", "<e1></e1>"), c("e2", "<e2></e2>"), c("e3", "<e3></e3>") );
+	};
+	
+	@Test
+	public void testXSDAllOneAlreadyExists() throws BadLocationException {
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<data\r\n" +
+			"    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" +
+			"    xsi:noNamespaceSchemaLocation=\"../xsd/modelGroup/all.xsd\">\r\n" +
+			"  <e3></e3>\r\n" +
+			"  |\r\n" +
+			"</data>\r\n";
+		XMLAssert.testCompletionFor(xml,  null, "src/test/resources/catalog/catalog.xml", 4, c("e1", "<e1></e1>"), c("e2", "<e2></e2>") );
+	};
+
+
 
 	private void testCompletionFor(String xml, CompletionItem... expectedItems) throws BadLocationException {
 		XMLAssert.testCompletionFor(xml, "src/test/resources/catalogs/catalog.xml", expectedItems);

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDCompletionExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDCompletionExtensionsTest.java
@@ -27,12 +27,26 @@ public class XSDCompletionExtensionsTest {
 	@Test
 	public void completion() throws BadLocationException {
 		// completion on |
-		String xml = "<?xml version=\"1.1\"?>\r\n"
-				+ "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\" attributeFormDefault=\"unqualified\">   \r\n"
-				+ //
+		String xml = 
+				"<?xml version=\"1.1\"?>\r\n" + 
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\" attributeFormDefault=\"unqualified\">   \r\n" + //
 				"|";
 		testCompletionFor(xml, c("xs:annotation", te(2, 0, 2, 0, "<xs:annotation></xs:annotation>"), "xs:annotation"),
-				c("xs:attribute", te(2, 0, 2, 0, "<xs:attribute name=\"\"></xs:attribute>"), "xs:attribute"));
+				c("xs:attribute", te(2, 0, 2, 0, "<xs:attribute name=\"\"></xs:attribute>"), "xs:attribute"),
+				c("xs:complexType", te(2, 0, 2, 0, "<xs:complexType name=\"\"></xs:complexType>"), "xs:complexType"));
+	}
+
+	@Test
+	public void completionAlreadyComplexType() throws BadLocationException {
+		// completion on |
+		String xml = 
+				"<?xml version=\"1.1\"?>\r\n" + 
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\" attributeFormDefault=\"unqualified\">   \r\n" + //
+				"  <xs:complexType></xs:complexType>\r\n" +
+				"  |";
+		testCompletionFor(xml, c("xs:annotation", te(2, 0, 2, 0, "<xs:annotation></xs:annotation>"), "xs:annotation"),
+				c("xs:attribute", te(2, 0, 2, 0, "<xs:attribute name=\"\"></xs:attribute>"), "xs:attribute"),
+				c("xs:complexType", te(2, 0, 2, 0, "<xs:complexType name=\"\"></xs:complexType>"), "xs:complexType"));
 	}
 
 	private void testCompletionFor(String xml, CompletionItem... expectedItems) throws BadLocationException {

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/extensions/HTMLCompletionExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/extensions/HTMLCompletionExtensionsTest.java
@@ -163,14 +163,14 @@ public class HTMLCompletionExtensionsTest {
 							if (index != -1) {
 								attribute = attribute.substring(0, index);
 							}
-							if (!completionResponse.hasAttribute(attribute)) {
+							if (!completionResponse.hasSeen(attribute)) {
 								CompletionItem item = new CompletionItem();
 								item.setLabel(attribute);
 								item.setKind(CompletionItemKind.Value);
 								String value = generateValue ? "=\"$1\"" : "";
 								item.setTextEdit(new TextEdit(replaceRange, attribute + value));
 								item.setInsertTextFormat(InsertTextFormat.Snippet);
-								completionResponse.addCompletionAttribute(item);
+								completionResponse.addCompletionItemAsSeen(item);
 							}
 						}
 					}
@@ -205,7 +205,7 @@ public class HTMLCompletionExtensionsTest {
 									item.setKind(CompletionItemKind.Unit);
 									item.setTextEdit(new TextEdit(fullRange, insertText));
 									item.setInsertTextFormat(InsertTextFormat.PlainText);
-									completionResponse.addCompletionAttribute(item);
+									completionResponse.addCompletionItemAsSeen(item);
 								}
 								break;
 							}

--- a/org.eclipse.lsp4xml/src/test/resources/catalogs/catalog.xml
+++ b/org.eclipse.lsp4xml/src/test/resources/catalogs/catalog.xml
@@ -25,6 +25,8 @@
 
 	<system systemId="http://money.xsd" uri="../xsd/money.xsd" />
 
+	<system systemId="http://sequence.xsd" uri="../xsd/modelGroup/sequence.xsd" /> 
+
 	<uri name="http://docs.oasis-open.org/odata/ns/edmx"
 		uri="../xsd/edmx.xsd" />
 	<uri name="http://docs.oasis-open.org/odata/ns/edm"

--- a/org.eclipse.lsp4xml/src/test/resources/xsd/modelGroup/all.xsd
+++ b/org.eclipse.lsp4xml/src/test/resources/xsd/modelGroup/all.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:element name="data">
+        <xs:complexType>
+            <xs:all>
+                <xs:element name="e1"/>
+                <xs:element name="e2"/>
+                <xs:element name="e3"/>
+            </xs:all>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/org.eclipse.lsp4xml/src/test/resources/xsd/modelGroup/choice.xsd
+++ b/org.eclipse.lsp4xml/src/test/resources/xsd/modelGroup/choice.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:element name="data">
+        <xs:complexType>
+            <xs:choice>
+                <xs:element name="e1"/>
+                <xs:element name="e2"/>
+                <xs:element name="e3"/>
+                
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/org.eclipse.lsp4xml/src/test/resources/xsd/modelGroup/choiceMaxOccurs.xsd
+++ b/org.eclipse.lsp4xml/src/test/resources/xsd/modelGroup/choiceMaxOccurs.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:element name="data">
+        <xs:complexType>
+            <xs:choice maxOccurs="3">
+                <xs:element name="e1"/>
+                <xs:element name="e2"/>
+                <xs:element name="e3" maxOccurs="2"/>
+                
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/org.eclipse.lsp4xml/src/test/resources/xsd/modelGroup/choiceMaxOccursOnlyChoice.xsd
+++ b/org.eclipse.lsp4xml/src/test/resources/xsd/modelGroup/choiceMaxOccursOnlyChoice.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:element name="data">
+        <xs:complexType>
+            <xs:choice maxOccurs="3">
+                <xs:element name="e1"/>
+                <xs:element name="e2"/>
+                <xs:element name="e3"/>
+                
+            </xs:choice>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/org.eclipse.lsp4xml/src/test/resources/xsd/modelGroup/sequence.xsd
+++ b/org.eclipse.lsp4xml/src/test/resources/xsd/modelGroup/sequence.xsd
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+    <xs:element name="data">
+        <xs:complexType>
+            <xs:sequence>
+								<xs:element name="optional0" minOccurs="0" maxOccurs="unbounded" />
+                <xs:element name="e1"/>
+								<xs:element name="optional1" minOccurs="0" maxOccurs="unbounded" />
+								<xs:element name="optional11" minOccurs="0" maxOccurs="2" />
+                <xs:element name="e2"/>
+								<xs:element name="optional2" minOccurs="0" />
+								<xs:element name="optional22" minOccurs="0" />
+                <xs:element name="e3"/>
+								<xs:element name="optional3" minOccurs="0" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/org.eclipse.lsp4xml/src/test/resources/xsd/modelGroup/sequenceMaxOccurs.xsd
+++ b/org.eclipse.lsp4xml/src/test/resources/xsd/modelGroup/sequenceMaxOccurs.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+    <xs:element name="data">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="e1"/>
+                <xs:element name="e2" maxOccurs="2"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/org.eclipse.lsp4xml/src/test/resources/xsd/modelGroup/sequenceSubstitutionGroup.xsd
+++ b/org.eclipse.lsp4xml/src/test/resources/xsd/modelGroup/sequenceSubstitutionGroup.xsd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+    <xs:element name="data">
+        <xs:complexType>
+            <xs:sequence>
+								<xs:element name="optional0" minOccurs="0" maxOccurs="unbounded" />
+                <xs:element name="e1"/>
+								<xs:element name="optional1" minOccurs="0" maxOccurs="unbounded" />
+								<xs:element ref="substituteElement" />
+								<xs:element name="optional11" minOccurs="0" maxOccurs="2" />
+                <xs:element name="e2" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+		<xs:element name="substituteElement" abstract="false" >
+		</xs:element>
+
+		<xs:element name="substituted1" substitutionGroup="substituteElement" />
+		<xs:element name="substituted2" substitutionGroup="substituteElement" />
+</xs:schema>

--- a/org.eclipse.lsp4xml/src/test/resources/xsd/xmlSchema.xsd
+++ b/org.eclipse.lsp4xml/src/test/resources/xsd/xmlSchema.xsd
@@ -1,0 +1,17 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+	<xs:element name="main">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:group ref="schemaTop"/>
+				<xs:element name="bbb" />
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:group name="schemaTop">
+		<xs:choice>
+			<xs:element name="element"/>
+			<xs:element name="attribute"/>
+			<xs:element name="notation"/>
+		</xs:choice>
+	</xs:group>
+</xs:schema>


### PR DESCRIPTION
This includes handling for (choice, all, and sequence)

Fixes #347