### PR TITLE
Attribute completion xsi:schemaLocation / xsi:noNamespaceSchemaLocation even if the other exists

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/DOMDocument.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/DOMDocument.java
@@ -249,10 +249,9 @@ public class DOMDocument extends DOMNode implements Document {
 				}
 			}
 			if (schemaInstancePrefix != null) {
+				// DOM document can declared xsi:noNamespaceSchemaLocation and xsi:schemaLocation both even it's not valid
 				noNamespaceSchemaLocation = createNoNamespaceSchemaLocation(documentElement, schemaInstancePrefix);
-				if (noNamespaceSchemaLocation == null) {
-					schemaLocation = createSchemaLocation(documentElement, schemaInstancePrefix);
-				}
+				schemaLocation = createSchemaLocation(documentElement, schemaInstancePrefix);				
 			}
 		}
 	}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsi/XSISchemaModel.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsi/XSISchemaModel.java
@@ -124,13 +124,14 @@ public class XSISchemaModel {
 		}
 		
 		if(inRootElement) {
-			if(!schemaLocationExists && !noNamespaceSchemaLocationExists) {
+			if(!schemaLocationExists) {
 				//The xsi:schemaLocation and xsi:noNamespaceSchemaLocation attributes can be used in a document 
 				//to provide hints as to the physical location of schema documents which may be used for ·assessment·.
 				documentation = SCHEMA_LOCATION_DOC;
 				name = actualPrefix + ":schemaLocation";
 				createCompletionItem(name, isSnippetsSupported, generateValue, editRange, null, null, documentation, response, settings);	
-				
+			}
+			if(!noNamespaceSchemaLocationExists) {
 				documentation = NO_NAMESPACE_SCHEMA_LOCATION_DOC;
 				name = actualPrefix + ":noNamespaceSchemaLocation";
 				createCompletionItem(name, isSnippetsSupported, generateValue, editRange, null, null, documentation, response, settings);	

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/dom/DOMDocumentTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/dom/DOMDocumentTest.java
@@ -263,4 +263,18 @@ public class DOMDocumentTest {
 		Assert.assertTrue(d.hasSchemaInstancePrefix());
 		Assert.assertTrue(d.usesSchema("/home/nikolas/nested/testXSD.xsd")); //bad path
 	}
+	
+	@Test
+	public void testNoNamespaceSchemaLocationAndShemaLocationBoth() {
+		String text = "<root\n" + //
+				"  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" + //
+				 "  xsi:noNamespaceSchemaLocation=\"/home/nikolas/nested/testXSD.xsd\"" + //
+				 " xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 testXSD.xsd\"" + //
+				 ">" + //
+				 " </root> ";
+		TextDocument textDocument = new TextDocument(text, "/home/test.xml");
+		DOMDocument d = DOMParser.getInstance().parse(text, textDocument.getUri(), null);
+		Assert.assertNotNull(d.getNoNamespaceSchemaLocation());
+		Assert.assertNotNull(d.getSchemaLocation());
+	}
 }

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaCompletionExtensionsTest.java
@@ -21,7 +21,6 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4xml.XMLAssert;
 import org.eclipse.lsp4xml.commons.BadLocationException;
 import org.eclipse.lsp4xml.services.XMLLanguageService;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -345,7 +344,7 @@ public class XMLSchemaCompletionExtensionsTest {
 				+ "            <xs:attribute name=\"variant\" type=\"xs:string\" use=\"required\"/>\r\n"
 				+ "        </xs:complexType>\r\n" + "    </xs:element>\r\n" + "</xs:schema>";
 		Files.write(Paths.get("target/xsd/resources.xsd"), schema.getBytes());
-		XMLAssert.testCompletionFor(xmlLanguageService, xml, null, null, "target/resources.xml", 4, false,
+		XMLAssert.testCompletionFor(xmlLanguageService, xml, null, null, "target/resources.xml", 5, false,
 				c("variant", "variant=\"\""));
 
 		// Update resources.xsd, Schema doesn't define variant attribute -> no
@@ -366,7 +365,7 @@ public class XMLSchemaCompletionExtensionsTest {
 				// + " <xs:attribute name=\"variant\" type=\"xs:string\" use=\"required\"/>\r\n"
 				+ "        </xs:complexType>\r\n" + "    </xs:element>\r\n" + "</xs:schema>";
 		Files.write(Paths.get("target/xsd/resources.xsd"), schema.getBytes());
-		XMLAssert.testCompletionFor(xmlLanguageService, xml, null, null, "target/resources.xml", 3, false);
+		XMLAssert.testCompletionFor(xmlLanguageService, xml, null, null, "target/resources.xml", 4, false);
 
 	}
 
@@ -448,7 +447,7 @@ public class XMLSchemaCompletionExtensionsTest {
 		"  <modelVersion></modelVersion>\r\n" +
 		"</project>";
 
-		XMLAssert.testCompletionFor(xml, 3, c("XXY:nil", "XXY:nil=\"true\""), c("XXY:type", "XXY:type=\"\""));
+		XMLAssert.testCompletionFor(xml, 4, c("XXY:nil", "XXY:nil=\"true\""), c("XXY:type", "XXY:type=\"\""), c("XXY:noNamespaceSchemaLocation", "XXY:noNamespaceSchemaLocation=\"\""));
 	}
 
 	@Test
@@ -485,7 +484,7 @@ public class XMLSchemaCompletionExtensionsTest {
 		"  <modelVersion></modelVersion>\r\n" +
 		"</project>";
 
-		XMLAssert.testCompletionFor(xml, 3, c("xsi:nil", "xsi:nil=\"true\""), c("xsi:type", "xsi:type=\"\""));
+		XMLAssert.testCompletionFor(xml, 4, c("xsi:nil", "xsi:nil=\"true\""), c("xsi:type", "xsi:type=\"\""), c("xsi:noNamespaceSchemaLocation", "xsi:noNamespaceSchemaLocation=\"\""));
 	}
 
 	@Test
@@ -498,7 +497,7 @@ public class XMLSchemaCompletionExtensionsTest {
 		"  <modelVersion></modelVersion>\r\n" +
 		"</project>";
 
-		XMLAssert.testCompletionFor(xml, 2, c("xsi:nil", "xsi:nil=\"true\""), c("xsi:type", "xsi:type=\"\""));
+		XMLAssert.testCompletionFor(xml, 3, c("xsi:nil", "xsi:nil=\"true\""), c("xsi:type", "xsi:type=\"\""), c("xsi:schemaLocation", "xsi:schemaLocation=\"\""));
 	}
 
 	private void testCompletionFor(String xml, CompletionItem... expectedItems) throws BadLocationException {

--- a/org.eclipse.lsp4xml/src/test/resources/xsd/differentNamespace/main.xml
+++ b/org.eclipse.lsp4xml/src/test/resources/xsd/differentNamespace/main.xml
@@ -1,0 +1,4 @@
+<zz:yesNS xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zz="http://gotNS" xsi:schemaLocation="http://gotNS xsd2Namespace.xsd" xsi:noNamespaceSchemaLocation="xsdNoNamespace.xsd">
+	<dog></dog>
+	
+</zz:yesNS>

--- a/org.eclipse.lsp4xml/src/test/resources/xsd/differentNamespace/xsd2Namespace.xsd
+++ b/org.eclipse.lsp4xml/src/test/resources/xsd/differentNamespace/xsd2Namespace.xsd
@@ -1,0 +1,11 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="http://gotNS">
+	<xs:element name="yesNS">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="dog"></xs:element>
+				<xs:any id="other"></xs:any>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/org.eclipse.lsp4xml/src/test/resources/xsd/differentNamespace/xsdNoNamespace.xsd
+++ b/org.eclipse.lsp4xml/src/test/resources/xsd/differentNamespace/xsdNoNamespace.xsd
@@ -1,0 +1,10 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:element name="noNS">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="noNSC1"></xs:element>
+				<xs:element name="noNSC2"></xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>


### PR DESCRIPTION
Originally did not provide completion for both schemaLocation and noNamespaceSchemaLocation if one already existed

