### PR TITLE
Fix error range for MarkupEntityMismatch 

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
@@ -157,8 +157,9 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 		case IllegalQName:
 		case InvalidCommentStart:
 		case MarkupNotRecognizedInContent:
-		case MarkupEntityMismatch:
 			return XMLPositionUtility.createRange(offset, offset + 1, document);
+		case MarkupEntityMismatch:
+			return XMLPositionUtility.selectRootStartTag(document);
 		case NameRequiredInReference:
 			break;
 		case OpenQuoteExpected: {

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/XMLPositionUtility.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/XMLPositionUtility.java
@@ -200,6 +200,11 @@ public class XMLPositionUtility {
 		return null;
 	}
 
+	public static Range selectRootStartTag(DOMDocument document) {
+		DOMNode root = document.getDocumentElement();
+		return selectStartTag(root);
+	}
+
 	public static Range selectStartTag(int offset, DOMDocument document) {
 		DOMNode element = document.findNodeAt(offset);
 		if (element != null) {

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
@@ -221,7 +221,7 @@ public class XMLSyntaxDiagnosticsTest {
 				+ "<Document xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"urn:iso:std:iso:20022:tech:xsd:pain.001.001.03\">\r\n"
 				+ "<CstmrCdtTrfInitn>\r\n" + //
 				"</CstmrCdtTrfInitn>";
-		testDiagnosticsFor(xml, d(3, 18, 3, 19, XMLSyntaxErrorCode.MarkupEntityMismatch));
+		testDiagnosticsFor(xml, d(1, 1, 1, 9, XMLSyntaxErrorCode.MarkupEntityMismatch));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #367 

The error range is now on the name of the root element's start tag.

![2019-05-22_14-47](https://user-images.githubusercontent.com/20326645/58200304-86d18380-7ca0-11e9-86cf-b7d9b0f1e6de.png)


