### PR TITLE
Fix https://github.com/angelozerr/lsp4xml/issues/386

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/dtd/contentmodel/CMDTDDocument.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/dtd/contentmodel/CMDTDDocument.java
@@ -101,7 +101,9 @@ public class CMDTDDocument extends XMLDTDLoader implements CMDocument {
 
 	@Override
 	public void element(String elementName, Augmentations augs) throws XNIException {
-		hierachies.add(elementName);
+		if (!hierachies.contains(elementName)) {
+			hierachies.add(elementName);
+		}
 		super.element(elementName, augs);
 	}
 


### PR DESCRIPTION
This PR fixes https://github.com/angelozerr/lsp4xml/issues/386 The problem comes from of populate of DTD element children when it is loaded. As elements can be declared in many area, we need to check that children element name was not added.

This PR is just to see how to fix problem. Please ignore it and creates a new PR with tests.