### PR TITLE
Fix normalizePath test on Windows OS

### DIFF
--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/utils/FilesUtilsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/utils/FilesUtilsTest.java
@@ -38,9 +38,9 @@ public class FilesUtilsTest {
 	@Test
 	public void normalizePathTest() {
 		assertEquals(Paths.get(System.getProperty("user.home"), "Test", "Folder").toString(), FilesUtils.normalizePath("~/Test/Folder"));
-		assertEquals(Paths.get(separator, "Test", "~", "Folder").toString(), FilesUtils.normalizePath("/Test/~/Folder"));
+		assertEquals(Paths.get(separator + "Test", "~", "Folder").toString(), FilesUtils.normalizePath("/Test/~/Folder"));
 		assertEquals(Paths.get("~", "Test", "Folder").toString(), FilesUtils.normalizePath("./~/Test/Folder"));
-		assertEquals(Paths.get(separator, "Folder").toString(), FilesUtils.normalizePath("/Test/../Folder"));
-		assertEquals(Paths.get(separator, "Users", "Nikolas").toString(), FilesUtils.normalizePath("\\Users\\Nikolas\\"));
+		assertEquals(Paths.get(separator +  "Folder").toString(), FilesUtils.normalizePath("/Test/../Folder"));
+		assertEquals(Paths.get(separator + "Users", "Nikolas").toString(), FilesUtils.normalizePath("\\Users\\Nikolas\\"));
 	}
 }


### PR DESCRIPTION
In Windows OS test with normalizePath failed. This PR should fix it.