### PR TITLE
Fix error range for ETagRequired

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/XMLPositionUtility.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/XMLPositionUtility.java
@@ -178,20 +178,32 @@ public class XMLPositionUtility {
 		if (parent == null || !parent.isElement() || ((DOMElement) parent).getTagName() == null) {
 			return null;
 		}
-		if (parent != null) {
-			DOMNode child = findChildNode(childTag, parent.getChildren());
-			if (child != null) {
+
+		DOMNode curr = parent;
+		DOMNode child;
+		while (curr != null) {
+			child = findUnclosedChildNode(childTag, curr.getChildren());
+			if (child == null) {
+				curr = findUnclosedChildNode(curr.getChildren());
+			} else {
 				return createRange(child.getStart() + 1, child.getStart() + 1 + childTag.length(), document);
 			}
-			if(parent.isElement()) {
-				String parentName = ((DOMElement) parent).getTagName();
-				return createRange(parent.getStart() + 2, parent.getStart() + 2 + parentName.length(), document);
+		}
+
+		String parentName = ((DOMElement) parent).getTagName();
+		return createRange(parent.getStart() + 2, parent.getStart() + 2 + parentName.length(), document);
+	}
+
+	public static DOMNode findUnclosedChildNode(List<DOMNode> children) {
+		for (DOMNode child: children) {
+			if (!child.isClosed()) {
+				return child;
 			}
 		}
 		return null;
 	}
 
-	static DOMNode findChildNode(String childTag, List<DOMNode> children) {
+	static DOMNode findUnclosedChildNode(String childTag, List<DOMNode> children) {
 		for (DOMNode child : children) {
 			if (child.isElement() && childTag != null && childTag.equals(((DOMElement) child).getTagName())
 					&& !child.isClosed()) {

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
@@ -167,6 +167,16 @@ public class XMLSyntaxDiagnosticsTest {
 		testDiagnosticsFor(xml, d(1, 13, 1, 15, XMLSyntaxErrorCode.ETagRequired));
 	}
 
+	@Test
+	public void testETagRequired3() throws Exception {
+		String xml = "<UltmtDbtr>\r\n" +
+				"    <Nm>Name</Nm>\r\n" +
+				"    <Ad>\r\n" +
+				"    <Ph>\r\n" +
+				"</UltmtDbtr>";
+		testDiagnosticsFor(xml, d(3, 5, 3, 7, XMLSyntaxErrorCode.ETagRequired));
+	}
+
 	/**
 	 * Test ETagUnterminated
 	 * 


### PR DESCRIPTION
This PR was previously approved here: https://github.com/angelozerr/lsp4xml/pull/395

Fixes #387

The error range is now as follows:

![image](https://user-images.githubusercontent.com/20326645/58639546-21dfe400-82c5-11e9-8d41-710cad666004.png)


Signed-off-by: David Kwon <dakwon@redhat.com>