### PR TITLE
Implement <?xml completion in DTD files

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/DTDDeclNode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/DTDDeclNode.java
@@ -13,6 +13,7 @@
 package org.eclipse.lsp4xml.dom;
 
 import java.util.ArrayList;
+import java.util.List;
 
 
 /**
@@ -33,7 +34,7 @@ public class DTDDeclNode extends DOMNode{
 	public DTDDeclParameter unrecognized; // holds all content after parsing goes wrong in a DTD declaration (ENTITY, ATTLIST, ...).
 	public DTDDeclParameter declType; // represents the actual name of the decl eg: ENTITY, ATTLIST, ...
 
-	ArrayList<DTDDeclParameter> parameters;
+	private List<DTDDeclParameter> parameters;
 
 	public DTDDeclNode(int start, int end, DOMDocumentType parentDocumentType) {
 		super(start, end);
@@ -84,7 +85,7 @@ public class DTDDeclNode extends DOMNode{
 		}
 	}
 
-	public ArrayList<DTDDeclParameter> getParameters() {
+	public List<DTDDeclParameter> getParameters() {
 		if(parameters == null) {
 			parameters = new ArrayList<DTDDeclParameter>();
 		}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/XMLPositionUtility.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/XMLPositionUtility.java
@@ -432,7 +432,7 @@ public class XMLPositionUtility {
 		DOMNode node = document.findNodeAt(offset);
 		if (node instanceof DTDDeclNode) {
 			DTDDeclNode decl = (DTDDeclNode) node;
-			ArrayList<DTDDeclParameter> params = decl.getParameters();
+			List<DTDDeclParameter> params = decl.getParameters();
 			DTDDeclParameter finalParam;
 			if(params == null || params.isEmpty()) {
 				return createRange(decl.declType.getStart(), decl.declType.getEnd(), document);
@@ -477,7 +477,7 @@ public class XMLPositionUtility {
 					decl = internal.get(internal.size() - 1); //get last internal decl
 				}
 			}
-			ArrayList<DTDDeclParameter> params = decl.getParameters();
+			List<DTDDeclParameter> params = decl.getParameters();
 			if(params == null || params.isEmpty()) {
 				return createRange(decl.declType.getStart(), decl.declType.getEnd(), document);
 			}
@@ -501,7 +501,7 @@ public class XMLPositionUtility {
 		DOMNode node = document.findNodeAt(offset);
 		if (node instanceof DTDDeclNode) {
 			DTDDeclNode decl = (DTDDeclNode) node;
-			ArrayList<DTDDeclParameter> params = decl.getParameters();
+			List<DTDDeclParameter> params = decl.getParameters();
 			DTDDeclParameter lastParam;
 			if(params != null && !params.isEmpty()) {
 				lastParam = params.get(params.size() - 1);
@@ -532,7 +532,7 @@ public class XMLPositionUtility {
 		DOMNode node = document.findNodeAt(offset);
 		if (node instanceof DTDElementDecl) {
 			DTDElementDecl declNode = (DTDElementDecl) node;
-			ArrayList<DTDDeclParameter> params = declNode.getParameters();
+			List<DTDDeclParameter> params = declNode.getParameters();
 			if(params.isEmpty()) {
 				return null;
 			}

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/dom/parser/XMLScannerForExternalDTDTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/dom/parser/XMLScannerForExternalDTDTest.java
@@ -264,6 +264,37 @@ public class XMLScannerForExternalDTDTest {
 	}
 
 	@Test
+	public void elementDeclContentWithProlog() {
+		String dtd =
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+		"<!ELEMENT note (to,from,heading,body)>";
+
+		scanner = XMLScanner.createScanner(dtd, true);
+
+		assertOffsetAndToken(0, TokenType.StartPrologOrPI);
+		assertOffsetAndToken(2, TokenType.PrologName, "xml");
+		assertOffsetAndToken(5, TokenType.Whitespace);
+		assertOffsetAndToken(6, TokenType.AttributeName);
+		assertOffsetAndToken(13, TokenType.DelimiterAssign);
+		assertOffsetAndToken(14, TokenType.AttributeValue);
+		assertOffsetAndToken(19, TokenType.Whitespace);
+		assertOffsetAndToken(20, TokenType.AttributeName);
+		assertOffsetAndToken(28, TokenType.DelimiterAssign);
+		assertOffsetAndToken(29, TokenType.AttributeValue);
+		assertOffsetAndToken(36, TokenType.PrologEnd);
+		assertOffsetAndToken(38, TokenType.Content);
+		assertOffsetAndToken(39, TokenType.DTDStartElement);
+		assertOffsetAndToken(48, TokenType.Whitespace);
+		assertOffsetAndToken(49, TokenType.DTDElementDeclName);
+		assertOffsetAndToken(53, TokenType.Whitespace);
+		assertOffsetAndToken(54, TokenType.DTDStartElementContent);
+		assertOffsetAndToken(55, TokenType.DTDElementContent);
+		assertOffsetAndToken(75, TokenType.DTDEndElementContent);
+		assertOffsetAndToken(76, TokenType.DTDEndTag);
+		assertOffsetAndToken(77, TokenType.EOS);
+	}
+
+	@Test
 	public void elementOnlyName() {
 		String dtd = "<!ELEMENT note > <!ENTITY>";
 		scanner = XMLScanner.createScanner(dtd, true);
@@ -364,6 +395,37 @@ public class XMLScannerForExternalDTDTest {
 		assertOffsetAndToken(31, TokenType.DTDAttlistAttributeValue);
 		assertOffsetAndToken(43, TokenType.DTDEndTag);
 		assertOffsetAndToken(44, TokenType.EOS);
+	}
+
+	@Test
+	public void attlistDeclWithProlog() {
+		String dtd =
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+		"<!ATTLIST elName attName CDATA \"defaultVal\">";
+		scanner = XMLScanner.createScanner(dtd, true);
+		assertOffsetAndToken(0, TokenType.StartPrologOrPI);
+		assertOffsetAndToken(2, TokenType.PrologName, "xml");
+		assertOffsetAndToken(5, TokenType.Whitespace);
+		assertOffsetAndToken(6, TokenType.AttributeName);
+		assertOffsetAndToken(13, TokenType.DelimiterAssign);
+		assertOffsetAndToken(14, TokenType.AttributeValue);
+		assertOffsetAndToken(19, TokenType.Whitespace);
+		assertOffsetAndToken(20, TokenType.AttributeName);
+		assertOffsetAndToken(28, TokenType.DelimiterAssign);
+		assertOffsetAndToken(29, TokenType.AttributeValue);
+		assertOffsetAndToken(36, TokenType.PrologEnd);
+		assertOffsetAndToken(38, TokenType.Content);
+		assertOffsetAndToken(39, TokenType.DTDStartAttlist);
+		assertOffsetAndToken(48, TokenType.Whitespace);
+		assertOffsetAndToken(49, TokenType.DTDAttlistElementName);
+		assertOffsetAndToken(55, TokenType.Whitespace);
+		assertOffsetAndToken(56, TokenType.DTDAttlistAttributeName);
+		assertOffsetAndToken(63, TokenType.Whitespace);
+		assertOffsetAndToken(64, TokenType.DTDAttlistAttributeType);
+		assertOffsetAndToken(69, TokenType.Whitespace);
+		assertOffsetAndToken(70, TokenType.DTDAttlistAttributeValue);
+		assertOffsetAndToken(82, TokenType.DTDEndTag);
+		assertOffsetAndToken(83, TokenType.EOS);
 	}
 
 	@Test

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/prolog/PrologCompletionExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/prolog/PrologCompletionExtensionsTest.java
@@ -181,8 +181,57 @@ public class PrologCompletionExtensionsTest {
 			"xml version=\"1.0\" encoding=\"UTF-8\"?>"));
 	}
 
+	@Test
+	public void testAutoCompletionPrologDTDFileWithXML() throws BadLocationException {
+		// With 'xml' label
+		String dtdFileURI = "test://test/test.dtd";
+		testCompletionFor("<?xml|", dtdFileURI, false, true, c("<?xml ... ?>", "xml version=\"1.0\" encoding=\"UTF-8\"?>$0", r(0, 2, 0, 5),
+			"xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+		testCompletionFor("<?xml|>", dtdFileURI, true, true, c("<?xml ... ?>", "xml version=\"1.0\" encoding=\"UTF-8\"?>$0", r(0, 2, 0, 6),
+			"xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+		testCompletionFor("<?xml|?>", dtdFileURI, true, true, c("<?xml ... ?>", "xml version=\"1.0\" encoding=\"UTF-8\"?>$0", r(0, 2, 0, 7),
+			"xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+	}
+
+	@Test
+	public void testAutoCompletionPrologDTDFileWithoutXML() throws BadLocationException {
+		//No 'xml' label
+		String dtdFileURI = "test://test/test.dtd";
+		testCompletionFor("<?|", dtdFileURI, false, true, c("<?xml ... ?>", "xml version=\"1.0\" encoding=\"UTF-8\"?>$0", r(0, 2, 0, 2),
+			"xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+		testCompletionFor("<?|", dtdFileURI, false, false, c("<?xml ... ?>", "xml version=\"1.0\" encoding=\"UTF-8\"?>", r(0, 2, 0, 2),
+			"xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+		testCompletionFor("<?|>", dtdFileURI, true, true, c("<?xml ... ?>", "xml version=\"1.0\" encoding=\"UTF-8\"?>$0", r(0, 2, 0, 3),
+			"xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+		testCompletionFor("<?|?>", dtdFileURI, true, true, c("<?xml ... ?>", "xml version=\"1.0\" encoding=\"UTF-8\"?>$0", r(0, 2, 0, 4),
+			"xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+	}
+
+	@Test
+	public void testAutoCompletionPrologDTFFileWithPartialXML() throws BadLocationException {
+		String dtdFileURI = "test://test/test.dtd";
+		testCompletionFor("<?x|", dtdFileURI, true, true, c("<?xml ... ?>", "xml version=\"1.0\" encoding=\"UTF-8\"?>$0", r(0, 2, 0, 3),
+			"xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+		testCompletionFor("<?xm|", dtdFileURI, true, true, c("<?xml ... ?>", "xml version=\"1.0\" encoding=\"UTF-8\"?>$0", r(0, 2, 0, 4),
+			"xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+		testCompletionFor("<?x|", dtdFileURI, true, true, c("<?xml ... ?>", "xml version=\"1.0\" encoding=\"UTF-8\"?>$0", r(0, 2, 0, 3),
+			"xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+		testCompletionFor("<?xm|?>", dtdFileURI, true, true, c("<?xml ... ?>", "xml version=\"1.0\" encoding=\"UTF-8\"?>$0", r(0, 2, 0, 6),
+			"xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+		testCompletionFor("<?xm|?>", dtdFileURI, true, false, c("<?xml ... ?>", "xml version=\"1.0\" encoding=\"UTF-8\"?>", r(0, 2, 0, 6),
+			"xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+	}
+
 	private void testCompletionFor(String xml, CompletionItem... expectedItems) throws BadLocationException {
 		XMLAssert.testCompletionFor(xml, null, expectedItems);
+	}
+
+	private void testCompletionFor(String xml, String fileURI, boolean autoCloseTags, boolean isSnippetsSupported, CompletionItem... expectedItems) throws BadLocationException {
+		testCompletionFor(xml, fileURI, formattingSettings, createCompletionSettings(autoCloseTags, isSnippetsSupported), expectedItems);
+	}
+
+	private void testCompletionFor(String xml, String fileURI, XMLFormattingOptions formattingSettings, CompletionSettings completionSettings, CompletionItem... expectedItems) throws BadLocationException {
+		XMLAssert.testCompletionFor(new XMLLanguageService(), xml, null, null, fileURI, null, completionSettings, formattingSettings, expectedItems);
 	}
 
 	private void testCompletionFor(String xml, boolean autoCloseTags, boolean isSnippetsSupported, CompletionItem... expectedItems) throws BadLocationException {

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLFormatterTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLFormatterTest.java
@@ -162,6 +162,15 @@ public class XMLFormatterTest {
 		format(content, expected);
 	}
 
+	@Test
+	public void testPINoContent() throws BadLocationException {
+		String content = "<a><?m2e?></a>";
+		String expected = "<a>" + lineSeparator() + //
+				"  <?m2e ?>" + lineSeparator() + //
+				"</a>";
+		format(content, expected);
+	}
+
 	@Ignore
 	@Test
 	public void testDefinedPIWithVariables() throws BadLocationException {
@@ -1500,7 +1509,7 @@ public class XMLFormatterTest {
 				"    </resource>\r\n" + 
 				"</resources>";
 		String expected = 
-				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + 
+				"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" + 
 				"<resources variant=\"\">\r\n" + 
 				"<resource name=\"res00\" >\r\n" + 
 				"<property name=\"propA\" value=\"...\" />\r\n" + 


### PR DESCRIPTION
Fixes #267

Previously, the prolog in `.dtd` files were not being parsed by the `DOMParser` as a `DOMProcessingInstruction`, like `.xml` files were.

Changing `XMLScanner.java` fixed that. Now that the prolog in `.dtd` files are considered to be a`DOMProcessingInstruction`, prolog auto-completion now works in `.dtd` files.

Since `.dtd` files could now contain a `DOMProcessingInstruction` in their respective `DOMDocument`, 
`XMLFormatter.java` had to be changed to take that into account. The "if else" structure in `XMLFormatter.java` was also cleaned up.  

Signed-off-by: David Kwon <dakwon@redhat.com>