### PR TITLE
Cancel support.

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLLanguageServer.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLLanguageServer.java
@@ -122,7 +122,8 @@ public class XMLLanguageServer
 		}
 		// Update client settings
 		initializationOptionsSettings = AllXMLSettings.getAllXMLSettings(initializationOptionsSettings);
-		XMLGeneralClientSettings xmlClientSettings = XMLGeneralClientSettings.getGeneralXMLSettings(initializationOptionsSettings);
+		XMLGeneralClientSettings xmlClientSettings = XMLGeneralClientSettings
+				.getGeneralXMLSettings(initializationOptionsSettings);
 		if (xmlClientSettings != null) {
 			// Update logs settings
 			LogsSettings logsSettings = xmlClientSettings.getLogs();
@@ -146,11 +147,11 @@ public class XMLLanguageServer
 			}
 
 			ServerSettings serverSettings = xmlClientSettings.getServer();
-			if(serverSettings != null) {
+			if (serverSettings != null) {
 				String workDir = serverSettings.getNormalizedWorkDir();
 				FilesUtils.setCachePathSetting(workDir);
 			}
-		
+
 			// Experimental capabilities
 			XMLExperimentalCapabilities experimental = xmlClientSettings.getExperimental();
 			if (experimental != null) {
@@ -160,11 +161,12 @@ public class XMLLanguageServer
 				xmlTextDocumentService.setIncrementalSupport(incrementalSupport);
 			}
 		}
-		ContentModelSettings cmSettings = ContentModelSettings.getContentModelXMLSettings(initializationOptionsSettings);
-		if(cmSettings != null) {
+		ContentModelSettings cmSettings = ContentModelSettings
+				.getContentModelXMLSettings(initializationOptionsSettings);
+		if (cmSettings != null) {
 			XMLValidationSettings validationSettings = cmSettings.getValidation();
 			xmlTextDocumentService.getValidationSettings().merge(validationSettings);
-			
+
 		}
 		// Update XML language service extensions
 		xmlTextDocumentService.updateSettings(initializationOptionsSettings);
@@ -224,10 +226,10 @@ public class XMLLanguageServer
 
 	@Override
 	public CompletableFuture<AutoCloseTagResponse> closeTag(TextDocumentPositionParams params) {
-		return computeAsync((monitor) -> {
-			TextDocument document = xmlTextDocumentService.getDocument(params.getTextDocument().getUri());
-			DOMDocument xmlDocument = xmlTextDocumentService.getXMLDocument(document);
-			return getXMLLanguageService().doAutoClose(xmlDocument, params.getPosition());
+		return computeAsync((cancelChecker) -> {
+			DOMDocument xmlDocument = xmlTextDocumentService.getXMLDocument(params.getTextDocument().getUri(),
+					cancelChecker);
+			return getXMLLanguageService().doAutoClose(xmlDocument, params.getPosition(), cancelChecker);
 		});
 	}
 

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/commons/LanguageModelCache.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/commons/LanguageModelCache.java
@@ -13,27 +13,29 @@ package org.eclipse.lsp4xml.commons;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
+import java.util.concurrent.CancellationException;
+import java.util.function.BiFunction;
 
 import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
 /**
  * Language model cache.
  * 
  * @see https://github.com/Microsoft/vscode/blob/master/extensions/json-language-features/server/src/languageModelCache.ts
  *
- * @param <T>
+ * @param <T> model type (ex : DOMDocument for XML).
  */
 public class LanguageModelCache<T> {
 
 	private final Map<String, LanguageModeInfo> languageModels;
-	private final Function<TextDocument, T> parse;
+	private final BiFunction<TextDocument, CancelChecker, T> parse;
 	private final ITextDocumentFactory documentFactory;
 
 	class LanguageModeInfo {
 
-		public final int version;
-		public final String languageId;
+		public int version;
+		public String languageId;
 		public long cTime;
 		public T languageModel;
 
@@ -43,10 +45,35 @@ public class LanguageModelCache<T> {
 			this.languageId = languageId;
 			this.cTime = cTime;
 		}
+
+		/**
+		 * Returns true if the given version and language id checks the version and
+		 * language id from the last cached model and false otherwise.
+		 * 
+		 * @param version    the version to chseck
+		 * @param languageId the language id to check
+		 * @return true if the given version and language id checks the version and
+		 *         language id from the last cached model and false otherwise.
+		 */
+		public boolean check(int version, String languageId) {
+			if (this.version > version) {
+				// Stop the process because the given version is more old than the cached model
+				// version
+				// This case comes from when there are an old request which comes after a new
+				// request.
+				throw new CancellationException("The version '" + version
+						+ "' is older than the cached model version '" + this.version + "'.");
+			}
+			if (this.version == version && Objects.equals(languageId, this.languageId)) {
+				cTime = System.currentTimeMillis();
+				return true;
+			}
+			return false;
+		}
 	}
 
 	public LanguageModelCache(int maxEntries, int cleanupIntervalTimeInSec, ITextDocumentFactory documentFactory,
-			Function<TextDocument, T> parse) {
+			BiFunction<TextDocument, CancelChecker, T> parse) {
 		this.languageModels = new HashMap<>();
 		this.parse = parse;
 		this.documentFactory = documentFactory;
@@ -56,37 +83,57 @@ public class LanguageModelCache<T> {
 		int version = document.getVersion();
 		String languageId = document.getLanguageId();
 		String uri = document.getUri();
-		T languageModel = getLanguageModel(version, languageId, uri);
-		if (languageModel != null) {
-			return languageModel;
-		}
-		return parseAndGet(document, version, languageId, uri);
-	}
+		// get the language model information
+		LanguageModeInfo languageModelInfo = getLanguageModelInfo(uri);
 
-	private T getLanguageModel(int version, String languageId, String uri) {
-		LanguageModeInfo languageModelInfo = languageModels.get(uri);
-		if (languageModelInfo != null && languageModelInfo.version == version
-				&& Objects.equals(languageId, languageModelInfo.languageId)) {
-			languageModelInfo.cTime = System.currentTimeMillis();
+		if (languageModelInfo.check(version, languageId)) {
+			// The language model checks the current version, returns the cached model (ex:
+			// DOMDocument instance)
 			return languageModelInfo.languageModel;
 		}
-		return null;
+
+		// Parse the model (ex: DOM document) from the given text document.
+		synchronized (languageModelInfo) {
+			if (languageModelInfo.check(version, languageId)) {
+				return languageModelInfo.languageModel;
+			}
+			TextDocument textDocument = document instanceof TextDocument ? (TextDocument) document
+					: documentFactory.createDocument(document);
+			languageModelInfo.languageModel = parse.apply(textDocument,
+					new TextDocumentVersionChecker(textDocument, version));
+			languageModelInfo.version = version;
+			languageModelInfo.languageId = languageId;
+		}
+		return languageModelInfo.languageModel;
 	}
 
-	private synchronized T parseAndGet(TextDocumentItem document, int version, String languageId, String uri) {
-		T languageModel = getLanguageModel(version, languageId, uri);
-		if (languageModel != null) {
-			return languageModel;
+	/**
+	 * Returns the language model information for the given uri
+	 * 
+	 * @param uri document uri
+	 * @return the language model information for the given uri
+	 */
+	private LanguageModeInfo getLanguageModelInfo(String uri) {
+		LanguageModeInfo languageModelInfo = languageModels.get(uri);
+		if (languageModelInfo != null) {
+			return languageModelInfo;
 		}
-		TextDocument textDocument = document instanceof TextDocument ? (TextDocument) document
-				: documentFactory.createDocument(document);
-		languageModel = parse.apply(textDocument);
-		languageModels.put(uri, new LanguageModeInfo(languageModel, version, languageId, System.currentTimeMillis()));
-		return languageModel;
+		// The information doesn't exists, create it
+		synchronized (languageModels) {
+			languageModelInfo = languageModels.get(uri);
+			if (languageModelInfo != null) {
+				return languageModelInfo;
+			}
+			languageModelInfo = new LanguageModeInfo(null, -1, null, -1);
+			languageModels.put(uri, languageModelInfo);
+		}
+		return languageModelInfo;
 	}
 
 	public void onDocumentRemoved(String uri) {
-		languageModels.remove(uri);
+		synchronized (languageModels) {
+			languageModels.remove(uri);
+		}
 	}
 
 }

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/commons/TextDocument.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/commons/TextDocument.java
@@ -28,7 +28,7 @@ public class TextDocument extends TextDocumentItem {
 
 	private static String DEFAULT_DELIMTER = System.lineSeparator();
 
-	private ListLineTracker lineTracker;
+	private final ListLineTracker lineTracker;
 
 	// Buffer of the text document used only in incremental mode.
 	private StringBuilder buffer;
@@ -40,8 +40,9 @@ public class TextDocument extends TextDocumentItem {
 	}
 
 	public TextDocument(String text, String uri) {
+		this.lineTracker = new ListLineTracker();
 		super.setUri(uri);
-		super.setText(text);
+		setText(text);
 	}
 
 	public void setIncremental(boolean incremental) {
@@ -55,7 +56,7 @@ public class TextDocument extends TextDocumentItem {
 	@Override
 	public void setText(String text) {
 		super.setText(text);
-		lineTracker = null;
+		lineTracker.set(text);
 	}
 
 	public Position positionAt(int position) throws BadLocationException {
@@ -117,10 +118,6 @@ public class TextDocument extends TextDocumentItem {
 	}
 
 	private ListLineTracker getLineTracker() {
-		if (lineTracker == null) {
-			lineTracker = new ListLineTracker();
-			lineTracker.set(super.getText());
-		}
 		return lineTracker;
 	}
 
@@ -147,7 +144,7 @@ public class TextDocument extends TextDocumentItem {
 							length = changeEvent.getRangeLength().intValue();
 						} else {
 							// range is optional and if not given, the whole file content is replaced
-							length = getText().length();
+							length = buffer.length();
 							range = new Range(positionAt(0), positionAt(length));
 						}
 						String text = changeEvent.getText();

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/commons/TextDocumentVersionChecker.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/commons/TextDocumentVersionChecker.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.commons;
+
+import java.util.concurrent.CancellationException;
+
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+
+/**
+ * A {@link CancelChecker} implementation to throw a
+ * {@link CancellationException} when version of {@link TextDocument} changed.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class TextDocumentVersionChecker implements CancelChecker {
+
+	private final TextDocument textDocument;
+
+	private final int version;
+
+	public TextDocumentVersionChecker(TextDocument textDocument, int version) {
+		this.textDocument = textDocument;
+		this.version = version;
+	}
+
+	@Override
+	public void checkCanceled() {
+		if (textDocument.getVersion() != version) {
+			// the text document version has changed
+			throw new CancellationException("Text document version '" + version + "' has changed to version '"
+					+ textDocument.getVersion() + ".");
+		}
+	}
+
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLCompletions.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLCompletions.java
@@ -28,6 +28,7 @@ import org.eclipse.lsp4j.InsertTextFormat;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4xml.commons.BadLocationException;
 import org.eclipse.lsp4xml.commons.TextDocument;
 import org.eclipse.lsp4xml.customservice.AutoCloseTagResponse;
@@ -64,7 +65,7 @@ public class XMLCompletions {
 	}
 
 	public CompletionList doComplete(DOMDocument xmlDocument, Position position,
-			SharedSettings settings) {
+			SharedSettings settings, CancelChecker cancelChecker) {
 		CompletionResponse completionResponse = new CompletionResponse();
 		CompletionRequest completionRequest = null;
 		try {
@@ -320,7 +321,7 @@ public class XMLCompletions {
 		return true;
 	}
 
-	public AutoCloseTagResponse doTagComplete(DOMDocument xmlDocument, Position position) {
+	public AutoCloseTagResponse doTagComplete(DOMDocument xmlDocument, Position position, CancelChecker cancelChecker) {
 		int offset;
 		try {
 			offset = xmlDocument.offsetAt(position);

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLFoldings.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLFoldings.java
@@ -25,6 +25,7 @@ import java.util.regex.Pattern;
 import org.eclipse.lsp4j.FoldingRange;
 import org.eclipse.lsp4j.FoldingRangeCapabilities;
 import org.eclipse.lsp4j.FoldingRangeKind;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4xml.commons.BadLocationException;
 import org.eclipse.lsp4xml.commons.TextDocument;
 import org.eclipse.lsp4xml.dom.parser.Scanner;
@@ -58,7 +59,7 @@ class XMLFoldings {
 		}
 	}
 
-	public List<FoldingRange> getFoldingRanges(TextDocument document, FoldingRangeCapabilities context) {		
+	public List<FoldingRange> getFoldingRanges(TextDocument document, FoldingRangeCapabilities context, CancelChecker cancelChecker) {		
 		Scanner scanner = XMLScanner.createScanner(document.getText());
 		TokenType token = scanner.scan();
 		List<FoldingRange> ranges = new ArrayList<>();
@@ -69,6 +70,7 @@ class XMLFoldings {
 
 		try {
 			while (token != TokenType.EOS) {
+				cancelChecker.checkCanceled();
 				switch (token) {
 				case StartTag: {
 					String tagName = scanner.getTokenText();

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLHighlighting.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLHighlighting.java
@@ -24,12 +24,14 @@ import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4xml.commons.BadLocationException;
 import org.eclipse.lsp4xml.dom.DOMDocument;
 import org.eclipse.lsp4xml.dom.DOMElement;
 import org.eclipse.lsp4xml.dom.DOMNode;
 import org.eclipse.lsp4xml.dom.parser.TokenType;
 import org.eclipse.lsp4xml.services.extensions.XMLExtensionsRegistry;
+
 /**
  * XML highlighting support.
  *
@@ -44,7 +46,8 @@ class XMLHighlighting {
 		this.extensionsRegistry = extensionsRegistry;
 	}
 
-	public List<DocumentHighlight> findDocumentHighlights(DOMDocument xmlDocument, Position position) {
+	public List<DocumentHighlight> findDocumentHighlights(DOMDocument xmlDocument, Position position,
+			CancelChecker cancelChecker) {
 		int offset = -1;
 		try {
 			offset = xmlDocument.offsetAt(position);
@@ -83,7 +86,8 @@ class XMLHighlighting {
 		} else if (node.isElement()) {
 			DOMElement element = (DOMElement) node;
 			startTagRange = getTagNameRange(TokenType.StartTag, node.getStart(), xmlDocument);
-			endTagRange = element.hasEndTag() ? getTagNameRange(TokenType.EndTag, element.getEndTagOpenOffset(), xmlDocument)
+			endTagRange = element.hasEndTag()
+					? getTagNameRange(TokenType.EndTag, element.getEndTagOpenOffset(), xmlDocument)
 					: null;
 			if (doesTagCoverPosition(startTagRange, endTagRange, position)) {
 				return getHighlightsList(startTagRange, endTagRange);

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLHover.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLHover.java
@@ -16,6 +16,7 @@ import java.util.logging.Logger;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4xml.commons.BadLocationException;
 import org.eclipse.lsp4xml.dom.DOMAttr;
 import org.eclipse.lsp4xml.dom.DOMDocument;
@@ -41,7 +42,7 @@ class XMLHover {
 		this.extensionsRegistry = extensionsRegistry;
 	}
 
-	public Hover doHover(DOMDocument xmlDocument, Position position) {
+	public Hover doHover(DOMDocument xmlDocument, Position position, CancelChecker cancelChecker) {
 		HoverRequest hoverRequest = null;
 		try {
 			hoverRequest = new HoverRequest(xmlDocument, position, extensionsRegistry);

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLSymbolsProvider.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLSymbolsProvider.java
@@ -14,6 +14,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -23,6 +25,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4xml.commons.BadLocationException;
 import org.eclipse.lsp4xml.dom.DOMDocument;
 import org.eclipse.lsp4xml.dom.DOMNode;
@@ -48,21 +51,27 @@ class XMLSymbolsProvider {
 		this.extensionsRegistry = extensionsRegistry;
 	}
 
-	public List<SymbolInformation> findSymbolInformations(DOMDocument xmlDocument) {
+	public List<SymbolInformation> findSymbolInformations(DOMDocument xmlDocument, CancelChecker cancelChecker) {
+		AtomicLong count = new AtomicLong();
 		List<SymbolInformation> symbols = new ArrayList<>();
 		boolean isDTD = xmlDocument.isDTD();
-		xmlDocument.getRoots().forEach(node -> {
+		for (DOMNode node : xmlDocument.getRoots()) {
 			try {
-				findSymbolInformations(node, "", symbols, (node.isDoctype() && isDTD));
+				findSymbolInformations(node, "", symbols, (node.isDoctype() && isDTD), count, cancelChecker);
 			} catch (BadLocationException e) {
 				LOGGER.log(Level.SEVERE,
 						"XMLSymbolsProvider#findSymbolInformations was given a BadLocation by a 'node' variable", e);
 			}
-		});
+		}
+		/* Uncomment that to avoid returning big symbol provider
+		 if (count.longValue() > 100) {
+			throw new CancellationException("too long");
+		}*/
 		return symbols;
 	}
 
-	public List<DocumentSymbol> findDocumentSymbols(DOMDocument xmlDocument) {
+	public List<DocumentSymbol> findDocumentSymbols(DOMDocument xmlDocument, CancelChecker cancelChecker) {
+		AtomicLong count = new AtomicLong();
 		List<DocumentSymbol> symbols = new ArrayList<>();
 		boolean isDTD = xmlDocument.isDTD();
 		List<DOMNode> nodesToIgnore = new ArrayList<>();
@@ -71,20 +80,26 @@ class XMLSymbolsProvider {
 				if ((node.isDoctype() && isDTD)) {
 					nodesToIgnore.add(node);
 				}
-				findDocumentSymbols(node, symbols, nodesToIgnore);
+				findDocumentSymbols(node, symbols, nodesToIgnore, count, cancelChecker);
 			} catch (BadLocationException e) {
 				LOGGER.log(Level.SEVERE,
 						"XMLSymbolsProvider#findDocumentSymbols was given a BadLocation by a 'node' variable", e);
 			}
 		});
+		/* Uncomment that to avoid returning big symbol provider
+		 if (count.longValue() > 100) {
+			throw new CancellationException("too long");
+		}*/
 		return symbols;
 	}
 
-	private void findDocumentSymbols(DOMNode node, List<DocumentSymbol> symbols, List<DOMNode> nodesToIgnore)
-			throws BadLocationException {
+	private void findDocumentSymbols(DOMNode node, List<DocumentSymbol> symbols, List<DOMNode> nodesToIgnore,
+			AtomicLong count, CancelChecker cancelChecker) throws BadLocationException {
 		if (!isNodeSymbol(node)) {
 			return;
 		}
+		cancelChecker.checkCanceled();
+
 		boolean hasChildNodes = node.hasChildNodes();
 		List<DocumentSymbol> childrenSymbols = symbols;
 		if (nodesToIgnore == null || !nodesToIgnore.contains(node)) {
@@ -95,46 +110,45 @@ class XMLSymbolsProvider {
 				DTDAttlistDecl decl = (DTDAttlistDecl) node;
 				name = decl.getElementName();
 				selectionRange = getSymbolRange(node, true);
-			}
-			else { // regular node
+			} else { // regular node
 				name = nodeToName(node);
 				selectionRange = getSymbolRange(node);
-				
+
 			}
 			Range range = selectionRange;
-			childrenSymbols = hasChildNodes || node.isDTDElementDecl() || node.isDTDAttListDecl() ? new ArrayList<>() : Collections.emptyList();
-			DocumentSymbol symbol = new DocumentSymbol(name, getSymbolKind(node), range, selectionRange, null, childrenSymbols);
+			childrenSymbols = hasChildNodes || node.isDTDElementDecl() || node.isDTDAttListDecl() ? new ArrayList<>()
+					: Collections.emptyList();
+			DocumentSymbol symbol = new DocumentSymbol(name, getSymbolKind(node), range, selectionRange, null,
+					childrenSymbols);
 			symbols.add(symbol);
+			count.incrementAndGet();
 
 			if (node.isDTDElementDecl() || (nodesToIgnore != null && node.isDTDAttListDecl())) {
 				// In the case of DTD ELEMENT we try to add in the children the DTD ATTLIST
 				Collection<DOMNode> attlistDecls;
-				if(node.isDTDElementDecl()) {
+				if (node.isDTDElementDecl()) {
 					DTDElementDecl elementDecl = (DTDElementDecl) node;
 					String elementName = elementDecl.getName();
 					attlistDecls = node.getOwnerDocument().findDTDAttrList(elementName);
-				}
-				else {
+				} else {
 					attlistDecls = new ArrayList<DOMNode>();
 					attlistDecls.add(node);
 				}
-				
+
 				for (DOMNode attrDecl : attlistDecls) {
-					findDocumentSymbols(attrDecl, childrenSymbols, null);
-					if(attrDecl instanceof DTDAttlistDecl) {
+					findDocumentSymbols(attrDecl, childrenSymbols, null, count, cancelChecker);
+					if (attrDecl instanceof DTDAttlistDecl) {
 						DTDAttlistDecl decl = (DTDAttlistDecl) attrDecl;
 						List<DTDAttlistDecl> otherAttributeDecls = decl.getInternalChildren();
-						if(otherAttributeDecls != null) {
+						if (otherAttributeDecls != null) {
 							for (DTDAttlistDecl internalDecl : otherAttributeDecls) {
-								findDocumentSymbols(internalDecl, childrenSymbols, null);
+								findDocumentSymbols(internalDecl, childrenSymbols, null, count, cancelChecker);
 							}
 						}
 					}
 					nodesToIgnore.add(attrDecl);
 				}
 			}
-
-			
 		}
 		if (!hasChildNodes) {
 			return;
@@ -142,7 +156,7 @@ class XMLSymbolsProvider {
 		final List<DocumentSymbol> childrenOfChild = childrenSymbols;
 		node.getChildren().forEach(child -> {
 			try {
-				findDocumentSymbols(child, childrenOfChild, nodesToIgnore);
+				findDocumentSymbols(child, childrenOfChild, nodesToIgnore, count, cancelChecker);
 			} catch (BadLocationException e) {
 				LOGGER.log(Level.SEVERE, "XMLSymbolsProvider was given a BadLocation by the provided 'node' variable",
 						e);
@@ -151,7 +165,7 @@ class XMLSymbolsProvider {
 	}
 
 	private void findSymbolInformations(DOMNode node, String container, List<SymbolInformation> symbols,
-			boolean ignoreNode) throws BadLocationException {
+			boolean ignoreNode, AtomicLong count, CancelChecker cancelChecker) throws BadLocationException {
 		if (!isNodeSymbol(node)) {
 			return;
 		}
@@ -162,12 +176,13 @@ class XMLSymbolsProvider {
 			Range range = getSymbolRange(node);
 			Location location = new Location(xmlDocument.getDocumentURI(), range);
 			SymbolInformation symbol = new SymbolInformation(name, getSymbolKind(node), location, container);
+			count.incrementAndGet();
 			symbols.add(symbol);
 		}
 		final String containerName = name;
 		node.getChildren().forEach(child -> {
 			try {
-				findSymbolInformations(child, containerName, symbols, false);
+				findSymbolInformations(child, containerName, symbols, false, count, cancelChecker);
 			} catch (BadLocationException e) {
 				LOGGER.log(Level.SEVERE, "XMLSymbolsProvider was given a BadLocation by the provided 'node' variable",
 						e);
@@ -175,26 +190,25 @@ class XMLSymbolsProvider {
 		});
 	}
 
-	private static Range getSymbolRange(DOMNode node)  throws BadLocationException{
+	private static Range getSymbolRange(DOMNode node) throws BadLocationException {
 		return getSymbolRange(node, false);
 	}
 
-	private static Range getSymbolRange(DOMNode node, boolean useAttlistElementName) throws BadLocationException{
+	private static Range getSymbolRange(DOMNode node, boolean useAttlistElementName) throws BadLocationException {
 		Position start;
 		Position end;
 		DOMDocument xmlDocument = node.getOwnerDocument();
 
-		if(node.isDTDAttListDecl() && !useAttlistElementName) {
+		if (node.isDTDAttListDecl() && !useAttlistElementName) {
 			DTDAttlistDecl attlistDecl = (DTDAttlistDecl) node;
 			DTDDeclParameter attributeNameDecl = attlistDecl.attributeName;
-			
-			if(attributeNameDecl != null) {
+
+			if (attributeNameDecl != null) {
 				start = xmlDocument.positionAt(attributeNameDecl.getStart());
 				end = xmlDocument.positionAt(attributeNameDecl.getEnd());
 				return new Range(start, end);
 			}
 		}
-		
 		start = xmlDocument.positionAt(node.getStart());
 		end = xmlDocument.positionAt(node.getEnd());
 		return new Range(start, end);
@@ -219,7 +233,8 @@ class XMLSymbolsProvider {
 
 	private static boolean isNodeSymbol(DOMNode node) {
 		return node.isElement() || node.isDoctype() || node.isProcessingInstruction() || node.isProlog()
-				|| node.isDTDElementDecl() || node.isDTDAttListDecl() || node.isDTDEntityDecl() || node.isDTDNotationDecl();
+				|| node.isDTDElementDecl() || node.isDTDAttListDecl() || node.isDTDEntityDecl()
+				|| node.isDTDNotationDecl();
 	}
 
 	private static String nodeToName(DOMNode node) {

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/XMLAssert.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/XMLAssert.java
@@ -121,13 +121,14 @@ public class XMLAssert {
 	public static void testCompletionFor(XMLLanguageService xmlLanguageService, String value, String catalogPath,
 			Consumer<XMLLanguageService> customConfiguration, String fileURI, Integer expectedCount,
 			CompletionSettings completionSettings, CompletionItem... expectedItems) throws BadLocationException {
-		testCompletionFor(xmlLanguageService, value, catalogPath, customConfiguration, fileURI, expectedCount, completionSettings, new XMLFormattingOptions(4, true), expectedItems);
+		testCompletionFor(xmlLanguageService, value, catalogPath, customConfiguration, fileURI, expectedCount,
+				completionSettings, new XMLFormattingOptions(4, true), expectedItems);
 	}
 
 	public static void testCompletionFor(XMLLanguageService xmlLanguageService, String value, String catalogPath,
 			Consumer<XMLLanguageService> customConfiguration, String fileURI, Integer expectedCount,
-			CompletionSettings completionSettings, XMLFormattingOptions formattingSettings, CompletionItem... expectedItems)
-			throws BadLocationException {
+			CompletionSettings completionSettings, XMLFormattingOptions formattingSettings,
+			CompletionItem... expectedItems) throws BadLocationException {
 		int offset = value.indexOf('|');
 		value = value.substring(0, offset) + value.substring(offset + 1);
 
@@ -205,7 +206,7 @@ public class XMLAssert {
 			Assert.assertEquals(expected.getFilterText(), match.getFilterText());
 		}
 
-		if(expected.getDetail() != null) {
+		if (expected.getDetail() != null) {
 			Assert.assertEquals(expected.getDetail(), match.getDetail());
 		}
 
@@ -251,7 +252,7 @@ public class XMLAssert {
 		DOMDocument htmlDoc = DOMParser.getInstance().parse(document, ls.getResolverExtensionManager());
 
 		AutoCloseTagResponse response = ls.doTagComplete(htmlDoc, position);
-		if(expected == null) {
+		if (expected == null) {
 			Assert.assertNull(response);
 			return;
 		}
@@ -287,7 +288,7 @@ public class XMLAssert {
 		}
 		testDiagnosticsFor(xml, catalogPath, configuration, fileURI, filter, settings, expected);
 	}
-	
+
 	public static void testDiagnosticsFor(String xml, String catalogPath, Consumer<XMLLanguageService> configuration,
 			String fileURI, boolean filter, ContentModelSettings settings, Diagnostic... expected) {
 		TextDocument document = new TextDocument(xml, fileURI != null ? fileURI : "test.xml");
@@ -305,7 +306,7 @@ public class XMLAssert {
 
 		List<Diagnostic> actual = xmlLanguageService.doDiagnostics(xmlDocument, () -> {
 		}, settings.getValidation());
-		if(expected == null) {
+		if (expected == null) {
 			assertTrue(actual.isEmpty());
 			return;
 		}
@@ -319,7 +320,7 @@ public class XMLAssert {
 	public static void assertDiagnostics(List<Diagnostic> actual, List<Diagnostic> expected, boolean filter) {
 		List<Diagnostic> received = actual;
 		final boolean filterMessage;
-		if(expected != null && !expected.isEmpty() && !StringUtils.isEmpty(expected.get(0).getMessage())) {
+		if (expected != null && !expected.isEmpty() && !StringUtils.isEmpty(expected.get(0).getMessage())) {
 			filterMessage = true;
 		} else {
 			filterMessage = false;
@@ -328,7 +329,7 @@ public class XMLAssert {
 			received = actual.stream().map(d -> {
 				Diagnostic simpler = new Diagnostic(d.getRange(), "");
 				simpler.setCode(d.getCode());
-				if(filterMessage) {
+				if (filterMessage) {
 					simpler.setMessage(d.getMessage());
 				}
 				return simpler;
@@ -346,7 +347,8 @@ public class XMLAssert {
 		return d(startLine, startCharacter, startLine, endCharacter, code);
 	}
 
-	public static Diagnostic d(int startLine, int startCharacter, int endLine, int endCharacter, IXMLErrorCode code, String message) {
+	public static Diagnostic d(int startLine, int startCharacter, int endLine, int endCharacter, IXMLErrorCode code,
+			String message) {
 		// Diagnostic on 1 line
 		return new Diagnostic(r(startLine, startCharacter, endLine, endCharacter), message, null, null, code.getCode());
 	}
@@ -395,10 +397,9 @@ public class XMLAssert {
 			XMLLanguageService languageService) {
 		CompletableFuture<Path> error = languageService.publishDiagnostics(xmlDocument, params -> {
 			actual.add(params);
-		}, (uri, version) -> {
+		}, (doc) -> {
 			// Retrigger validation
 			publishDiagnostics(xmlDocument, actual, languageService);
-		}, () -> {
 		}, null);
 
 		if (error != null) {
@@ -427,11 +428,11 @@ public class XMLAssert {
 		SharedSettings settings = new SharedSettings();
 		settings.setFormattingSettings(new XMLFormattingOptions(4, false));
 		testCodeActionsFor(xml, diagnostic, catalogPath, settings, expected);
-		
+
 	}
 
-	public static void testCodeActionsFor(String xml, Diagnostic diagnostic, String catalogPath, SharedSettings sharedSettings,
-			CodeAction... expected) {
+	public static void testCodeActionsFor(String xml, Diagnostic diagnostic, String catalogPath,
+			SharedSettings sharedSettings, CodeAction... expected) {
 		TextDocument document = new TextDocument(xml.toString(), FILE_URI);
 
 		XMLLanguageService xmlLanguageService = new XMLLanguageService();
@@ -450,14 +451,12 @@ public class XMLAssert {
 		DOMDocument xmlDoc = DOMParser.getInstance().parse(document, xmlLanguageService.getResolverExtensionManager());
 
 		XMLFormattingOptions formattingSettings;
-		if(sharedSettings != null && sharedSettings.formattingSettings != null) {
+		if (sharedSettings != null && sharedSettings.formattingSettings != null) {
 			formattingSettings = sharedSettings.formattingSettings;
-		}
-		else {
+		} else {
 			formattingSettings = new XMLFormattingOptions(4, false);
 		}
-		List<CodeAction> actual = xmlLanguageService.doCodeActions(context, range, xmlDoc,
-				formattingSettings);
+		List<CodeAction> actual = xmlLanguageService.doCodeActions(context, range, xmlDoc, formattingSettings);
 		assertCodeActions(actual, expected);
 	}
 

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/commons/LanguageModelCacheTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/commons/LanguageModelCacheTest.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.commons;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4xml.dom.DOMDocument;
+import org.eclipse.lsp4xml.dom.DOMParser;
+import org.eclipse.lsp4xml.utils.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test with language model cache
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class LanguageModelCacheTest {
+
+	@Test
+	public void testModelCache() {
+
+		LanguageModelCache<DOMDocument> cache = new LanguageModelCache<DOMDocument>(10, 60, new TextDocuments(),
+				(document, monitor) -> {
+					return DOMParser.getInstance().parse(document, null);
+				});
+
+		Set<DOMDocument> documents = new HashSet<DOMDocument>();
+
+		String text = IOUtils.convertStreamToString(LanguageModelCacheTest.class.getResourceAsStream("/xml/nasa.xml"));
+		int version = 0;
+
+		AtomicBoolean hasCancellationException = new AtomicBoolean(false);
+
+		// Create 100 threads which get the nasa.xml file from the cache
+		List<Thread> threads = new ArrayList<>();
+		for (int i = 0; i < 100; i++) {
+
+			final TextDocumentItem document = new TextDocumentItem();
+			document.setLanguageId("xml");
+			document.setUri("test.xml");
+			document.setText(text);
+
+			if (i % 20 == 0) {
+				document.setVersion(version++);
+			}
+			Thread t = new Thread(() -> {
+				try {
+					// get DOM document from the cache and parse it if needed
+					DOMDocument dom = cache.get(document);
+					documents.add(dom);
+				} catch (CancellationException e) {
+					// This exception occurs when document version is older than cache model version
+					hasCancellationException.set(true);
+				}
+			});
+			threads.add(t);
+		}
+
+		// Execute the threads
+		for (Thread thread : threads) {
+			thread.start();
+		}
+
+		// Wait for all processes of the threads
+		for (Thread thread : threads) {
+			try {
+				thread.join();
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+
+		Assert.assertTrue("Has older version than model cache version", hasCancellationException.get());
+		Assert.assertTrue("DOM document instances", documents.size() <= version);
+
+	}
+}

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/dom/DOMDocumentVersionCheckerTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/dom/DOMDocumentVersionCheckerTest.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.dom;
+
+import java.util.concurrent.CancellationException;
+
+import org.eclipse.lsp4xml.commons.BadLocationException;
+import org.eclipse.lsp4xml.commons.TextDocument;
+import org.eclipse.lsp4xml.commons.TextDocumentVersionChecker;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test to stop parse of {@link DOMDocument} when current version is not
+ * synchronized with the version of {@link TextDocument}.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class DOMDocumentVersionCheckerTest {
+
+	@Test
+	public void stopDOMParsing() {
+
+		TextDocument textDocument = createTextDocument();
+		int version = 1;
+		textDocument.setVersion(version);
+
+		// text document version and checker version are synchronized -> parse should be
+		// done
+		CancellationException ex = null;
+		TextDocumentVersionChecker checker = new TextDocumentVersionChecker(textDocument, version);
+		try {
+			DOMParser.getInstance().parse(textDocument, null, true, checker);
+		} catch (CancellationException e) {
+			ex = e;
+		}
+		Assert.assertNull(ex);
+
+		// text document version and checker version are NOT synchronized -> parse
+		// should be stopped
+		ex = null;
+		version = 2;
+		textDocument.setVersion(version);
+		try {
+			DOMParser.getInstance().parse(textDocument, null, true, checker);
+		} catch (CancellationException e) {
+			ex = e;
+		}
+		Assert.assertNotNull(ex);
+
+		// text document version and checker version are synchronized -> parse should be
+		// done
+		ex = null;
+		checker = new TextDocumentVersionChecker(textDocument, version);
+		try {
+			DOMParser.getInstance().parse(textDocument, null, true, checker);
+		} catch (CancellationException e) {
+			ex = e;
+		}
+		Assert.assertNull(ex);
+	}
+
+	@Test
+	public void positionAt() throws BadLocationException {
+		TextDocument textDocument = createTextDocument();
+		int version = 1;
+		textDocument.setVersion(version);
+
+		TextDocumentVersionChecker checker = new TextDocumentVersionChecker(textDocument, version);
+		DOMDocument document = DOMParser.getInstance().parse(textDocument, null, true, checker);
+
+		// text document version and checker version are synchronized -> call of
+		// positionAt (which uses line tracker) should work
+		CancellationException ex = null;
+		try {
+			document.positionAt(0);
+		} catch (CancellationException e) {
+			ex = e;
+		}
+		Assert.assertNull(ex);
+
+		// text document version and checker version are NOT synchronized -> call of
+		// positionAt (which uses line tracker) should NOT work
+		ex = null;
+		textDocument.setVersion(++version);
+		try {
+			document.positionAt(0);
+		} catch (CancellationException e) {
+			ex = e;
+		}
+		Assert.assertNotNull(ex);
+	}
+
+	private static TextDocument createTextDocument() {
+		return new TextDocument("<root />", "nasa.xml");
+	}
+}

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLFoldingsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLFoldingsTest.java
@@ -17,6 +17,8 @@ import java.util.List;
 import org.eclipse.lsp4j.FoldingRange;
 import org.eclipse.lsp4j.FoldingRangeCapabilities;
 import org.eclipse.lsp4xml.commons.TextDocument;
+import org.eclipse.lsp4xml.dom.DOMDocument;
+import org.eclipse.lsp4xml.dom.DOMParser;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -222,12 +224,12 @@ public class XMLFoldingsTest {
 
 	private static void assertRanges(String[] lines, ExpectedIndentRange[] expected, String message, Integer nRanges) {
 		TextDocument document = new TextDocument(String.join("\n", lines), "test://foo/bar.json");
-
+		DOMDocument xmlDocument = DOMParser.getInstance().parse(document, null);
 		XMLLanguageService languageService = new XMLLanguageService();
 
 		FoldingRangeCapabilities context = new FoldingRangeCapabilities();
 		context.setRangeLimit(nRanges);
-		List<FoldingRange> actual = languageService.getFoldingRanges(document, context);
+		List<FoldingRange> actual = languageService.getFoldingRanges(xmlDocument, context);
 
 		List<ExpectedIndentRange> actualRanges = new ArrayList<>();
 		for (FoldingRange f : actual) {


### PR DESCRIPTION
The basic idea is to cancel:

 - LSP requests which are executed on each change of text editor like
symbol provider, highligtings, hover, closeTag, etc
 - parse of DOM Document

This cancel support will improve performance and memory too.

Fixes #409