### PR TITLE
Display Java runtime used to launch the server

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLLanguageServer.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLLanguageServer.java
@@ -80,7 +80,7 @@ public class XMLLanguageServer
 
 	@Override
 	public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
-		LOGGER.info("Initializing LSP4XML server " + getVersion());
+		LOGGER.info("Initializing LSP4XML server " + getVersion()+" with " + System.getProperty("java.home"));
 		this.parentProcessId = params.getProcessId();
 
 		// Update XML language service extensions with InitializeParams


### PR DESCRIPTION
Useful for debugging purposes:
```
[Trace - 4:17:19 PM] Sending request 'initialize - (0)'.
Jun. 04, 2019 4:17:19 P.M. org.eclipse.lsp4xml.XMLLanguageServer initialize
INFO: Initializing LSP4XML server 0.7.0-20190604-2016 with /Users/fbricon/.sdkman/candidates/java/12.0.0-open
```