### PR TITLE
Cancel support to fix #409

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLLanguageServer.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLLanguageServer.java
@@ -122,7 +122,8 @@ public class XMLLanguageServer
 		}
 		// Update client settings
 		initializationOptionsSettings = AllXMLSettings.getAllXMLSettings(initializationOptionsSettings);
-		XMLGeneralClientSettings xmlClientSettings = XMLGeneralClientSettings.getGeneralXMLSettings(initializationOptionsSettings);
+		XMLGeneralClientSettings xmlClientSettings = XMLGeneralClientSettings
+				.getGeneralXMLSettings(initializationOptionsSettings);
 		if (xmlClientSettings != null) {
 			// Update logs settings
 			LogsSettings logsSettings = xmlClientSettings.getLogs();
@@ -146,11 +147,11 @@ public class XMLLanguageServer
 			}
 
 			ServerSettings serverSettings = xmlClientSettings.getServer();
-			if(serverSettings != null) {
+			if (serverSettings != null) {
 				String workDir = serverSettings.getNormalizedWorkDir();
 				FilesUtils.setCachePathSetting(workDir);
 			}
-		
+
 			// Experimental capabilities
 			XMLExperimentalCapabilities experimental = xmlClientSettings.getExperimental();
 			if (experimental != null) {
@@ -160,11 +161,12 @@ public class XMLLanguageServer
 				xmlTextDocumentService.setIncrementalSupport(incrementalSupport);
 			}
 		}
-		ContentModelSettings cmSettings = ContentModelSettings.getContentModelXMLSettings(initializationOptionsSettings);
-		if(cmSettings != null) {
+		ContentModelSettings cmSettings = ContentModelSettings
+				.getContentModelXMLSettings(initializationOptionsSettings);
+		if (cmSettings != null) {
 			XMLValidationSettings validationSettings = cmSettings.getValidation();
 			xmlTextDocumentService.getValidationSettings().merge(validationSettings);
-			
+
 		}
 		// Update XML language service extensions
 		xmlTextDocumentService.updateSettings(initializationOptionsSettings);
@@ -224,10 +226,10 @@ public class XMLLanguageServer
 
 	@Override
 	public CompletableFuture<AutoCloseTagResponse> closeTag(TextDocumentPositionParams params) {
-		return computeAsync((monitor) -> {
-			TextDocument document = xmlTextDocumentService.getDocument(params.getTextDocument().getUri());
-			DOMDocument xmlDocument = xmlTextDocumentService.getXMLDocument(document);
-			return getXMLLanguageService().doAutoClose(xmlDocument, params.getPosition());
+		return computeAsync((cancelChecker) -> {
+			DOMDocument xmlDocument = xmlTextDocumentService.getXMLDocument(params.getTextDocument().getUri(),
+					cancelChecker);
+			return getXMLLanguageService().doAutoClose(xmlDocument, params.getPosition(), cancelChecker);
 		});
 	}
 

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLTextDocumentService.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLTextDocumentService.java
@@ -21,7 +21,6 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -65,6 +64,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4xml.commons.LanguageModelCache;
 import org.eclipse.lsp4xml.commons.TextDocument;
+import org.eclipse.lsp4xml.commons.TextDocumentVersionChecker;
 import org.eclipse.lsp4xml.commons.TextDocuments;
 import org.eclipse.lsp4xml.dom.DOMDocument;
 import org.eclipse.lsp4xml.dom.DOMParser;
@@ -86,23 +86,6 @@ public class XMLTextDocumentService implements TextDocumentService {
 	private final TextDocuments documents;
 	private final LanguageModelCache<DOMDocument> xmlDocuments;
 	private SharedSettings sharedSettings;
-
-	class BasicCancelChecker implements CancelChecker {
-
-		private boolean canceled;
-
-		@Override
-		public void checkCanceled() {
-			if (canceled) {
-				throw new CancellationException();
-			}
-		}
-
-		public void setCanceled(boolean canceled) {
-			this.canceled = canceled;
-		}
-
-	}
 
 	/**
 	 * Save context.
@@ -142,8 +125,6 @@ public class XMLTextDocumentService implements TextDocumentService {
 	}
 
 	final ScheduledExecutorService delayer = Executors.newScheduledThreadPool(2);
-	private ScheduledFuture<?> future;
-	private BasicCancelChecker monitor;
 	private boolean codeActionLiteralSupport;
 	private boolean hierarchicalDocumentSymbolSupport;
 
@@ -151,8 +132,8 @@ public class XMLTextDocumentService implements TextDocumentService {
 		this.xmlLanguageServer = xmlLanguageServer;
 		this.documents = new TextDocuments();
 		DOMParser parser = DOMParser.getInstance();
-		this.xmlDocuments = new LanguageModelCache<DOMDocument>(10, 60, documents, document -> {
-			return parser.parse(document, getXMLLanguageService().getResolverExtensionManager());
+		this.xmlDocuments = new LanguageModelCache<DOMDocument>(10, 60, documents, (document, cancelChecker) -> {
+			return parser.parse(document, getXMLLanguageService().getResolverExtensionManager(), true, cancelChecker);
 		});
 
 		this.sharedSettings = new SharedSettings();
@@ -179,23 +160,32 @@ public class XMLTextDocumentService implements TextDocumentService {
 		return xmlDocuments.get(document);
 	}
 
+	public DOMDocument getXMLDocument(String uri, CancelChecker cancelChecker) {
+		TextDocument document = getDocument(uri, cancelChecker);
+		cancelChecker.checkCanceled();
+		return getXMLDocument(document);
+	}
+
+	TextDocument getDocument(String uri, CancelChecker cancelChecker) {
+		cancelChecker.checkCanceled();
+		return getDocument(uri);
+	}
+
 	@Override
 	public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams params) {
-		return computeAsync((monitor) -> {
-			String uri = params.getTextDocument().getUri();
-			TextDocument document = getDocument(uri);
-			DOMDocument xmlDocument = getXMLDocument(document);
-			CompletionList list = getXMLLanguageService().doComplete(xmlDocument, params.getPosition(), sharedSettings);
+		return computeAsync((cancelChecker) -> {
+			DOMDocument xmlDocument = getXMLDocument(params.getTextDocument().getUri(), cancelChecker);
+			CompletionList list = getXMLLanguageService().doComplete(xmlDocument, params.getPosition(), sharedSettings,
+					cancelChecker);
 			return Either.forRight(list);
 		});
 	}
 
 	@Override
 	public CompletableFuture<Hover> hover(TextDocumentPositionParams params) {
-		return computeAsync((monitor) -> {
-			TextDocument document = getDocument(params.getTextDocument().getUri());
-			DOMDocument xmlDocument = getXMLDocument(document);
-			return getXMLLanguageService().doHover(xmlDocument, params.getPosition());
+		return computeAsync((cancelChecker) -> {
+			DOMDocument xmlDocument = getXMLDocument(params.getTextDocument().getUri(), cancelChecker);
+			return getXMLLanguageService().doHover(xmlDocument, params.getPosition(), cancelChecker);
 		});
 	}
 
@@ -207,26 +197,22 @@ public class XMLTextDocumentService implements TextDocumentService {
 
 	@Override
 	public CompletableFuture<List<? extends DocumentHighlight>> documentHighlight(TextDocumentPositionParams params) {
-		return computeAsync((monitor) -> {
-			TextDocument document = getDocument(params.getTextDocument().getUri());
-			DOMDocument xmlDocument = getXMLDocument(document);
-			return getXMLLanguageService().findDocumentHighlights(xmlDocument, params.getPosition());
+		return computeAsync((cancelChecker) -> {
+			DOMDocument xmlDocument = getXMLDocument(params.getTextDocument().getUri(), cancelChecker);
+			return getXMLLanguageService().findDocumentHighlights(xmlDocument, params.getPosition(), cancelChecker);
 		});
 	}
 
 	@Override
 	public CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> documentSymbol(
 			DocumentSymbolParams params) {
-		
-		if(!sharedSettings.symbolSettings.isEnabled()) {
+		if (!sharedSettings.symbolSettings.isEnabled()) {
 			return CompletableFuture.completedFuture(Collections.emptyList());
 		}
-
-		return computeAsync((monitor) -> {
-			TextDocument document = getDocument(params.getTextDocument().getUri());
-			DOMDocument xmlDocument = getXMLDocument(document);
+		return computeAsync((cancelChecker) -> {
+			DOMDocument xmlDocument = getXMLDocument(params.getTextDocument().getUri(), cancelChecker);
 			if (hierarchicalDocumentSymbolSupport) {
-				return getXMLLanguageService().findDocumentSymbols(xmlDocument) //
+				return getXMLLanguageService().findDocumentSymbols(xmlDocument, cancelChecker) //
 						.stream() //
 						.map(s -> {
 							Either<SymbolInformation, DocumentSymbol> e = Either.forRight(s);
@@ -234,7 +220,7 @@ public class XMLTextDocumentService implements TextDocumentService {
 						}) //
 						.collect(Collectors.toList());
 			}
-			return getXMLLanguageService().findSymbolInformations(xmlDocument) //
+			return getXMLLanguageService().findSymbolInformations(xmlDocument, cancelChecker) //
 					.stream() //
 					.map(s -> {
 						Either<SymbolInformation, DocumentSymbol> e = Either.forLeft(s);
@@ -246,9 +232,9 @@ public class XMLTextDocumentService implements TextDocumentService {
 
 	@Override
 	public CompletableFuture<List<? extends TextEdit>> formatting(DocumentFormattingParams params) {
-		return computeAsync((monitor) -> {
+		return computeAsync((cancelChecker) -> {
 			String uri = params.getTextDocument().getUri();
-			TextDocument document = getDocument(uri);
+			TextDocument document = getDocument(uri, cancelChecker);
 			return getXMLLanguageService().format(document, null,
 					XMLFormattingOptions.create(params.getOptions(), getFormattingSettings(uri)));
 		});
@@ -256,9 +242,9 @@ public class XMLTextDocumentService implements TextDocumentService {
 
 	@Override
 	public CompletableFuture<List<? extends TextEdit>> rangeFormatting(DocumentRangeFormattingParams params) {
-		return computeAsync((monitor) -> {
+		return computeAsync((cancelChecker) -> {
 			String uri = params.getTextDocument().getUri();
-			TextDocument document = getDocument(uri);
+			TextDocument document = getDocument(uri, cancelChecker);
 			return getXMLLanguageService().format(document, params.getRange(),
 					XMLFormattingOptions.create(params.getOptions(), getFormattingSettings(uri)));
 		});
@@ -275,17 +261,17 @@ public class XMLTextDocumentService implements TextDocumentService {
 
 	@Override
 	public void didOpen(DidOpenTextDocumentParams params) {
-		documents.onDidOpenTextDocument(params);
-		triggerValidation(params.getTextDocument().getUri(), params.getTextDocument().getVersion());
+		TextDocument document = documents.onDidOpenTextDocument(params);
+		triggerValidationFor(document);
 	}
 
-	@Override
 	/**
 	 * This method is triggered when the user types on an XML document.
 	 */
+	@Override
 	public void didChange(DidChangeTextDocumentParams params) {
-		documents.onDidChangeTextDocument(params);
-		triggerValidation(params.getTextDocument().getUri(), params.getTextDocument().getVersion());
+		TextDocument document = documents.onDidChangeTextDocument(params);
+		triggerValidationFor(document);
 	}
 
 	@Override
@@ -296,22 +282,20 @@ public class XMLTextDocumentService implements TextDocumentService {
 		String uri = document.getUri();
 		xmlLanguageServer.getLanguageClient()
 				.publishDiagnostics(new PublishDiagnosticsParams(uri, new ArrayList<Diagnostic>()));
-
 	}
 
 	@Override
 	public CompletableFuture<List<FoldingRange>> foldingRange(FoldingRangeRequestParams params) {
-		return computeAsync((monitor) -> {
-			TextDocument document = getDocument(params.getTextDocument().getUri());
-			return getXMLLanguageService().getFoldingRanges(document, sharedSettings.foldingSettings);
+		return computeAsync((cancelChecker) -> {
+			DOMDocument xmlDocument = getXMLDocument(params.getTextDocument().getUri(), cancelChecker);
+			return getXMLLanguageService().getFoldingRanges(xmlDocument, sharedSettings.foldingSettings, cancelChecker);
 		});
 	}
 
 	@Override
 	public CompletableFuture<List<DocumentLink>> documentLink(DocumentLinkParams params) {
-		return computeAsync((monitor) -> {
-			TextDocument document = getDocument(params.getTextDocument().getUri());
-			DOMDocument xmlDocument = getXMLDocument(document);
+		return computeAsync((cancelChecker) -> {
+			DOMDocument xmlDocument = getXMLDocument(params.getTextDocument().getUri(), cancelChecker);
 			return getXMLLanguageService().findDocumentLinks(xmlDocument);
 		});
 	}
@@ -319,9 +303,8 @@ public class XMLTextDocumentService implements TextDocumentService {
 	@Override
 	public CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> definition(
 			TextDocumentPositionParams params) {
-		return computeAsync((monitor) -> {
-			TextDocument document = getDocument(params.getTextDocument().getUri());
-			DOMDocument xmlDocument = getXMLDocument(document);
+		return computeAsync((cancelChecker) -> {
+			DOMDocument xmlDocument = getXMLDocument(params.getTextDocument().getUri(), cancelChecker);
 			Either e = Either.forLeft(getXMLLanguageService().findDefinition(xmlDocument, params.getPosition()));
 			return e;
 		});
@@ -329,8 +312,8 @@ public class XMLTextDocumentService implements TextDocumentService {
 
 	@Override
 	public CompletableFuture<List<? extends Location>> references(ReferenceParams params) {
-		return computeAsync((monitor) -> {
-			TextDocument document = getDocument(params.getTextDocument().getUri());
+		return computeAsync((cancelChecker) -> {
+			TextDocument document = getDocument(params.getTextDocument().getUri(), cancelChecker);
 			DOMDocument xmlDocument = getXMLDocument(document);
 			return getXMLLanguageService().findReferences(xmlDocument, params.getPosition(), params.getContext());
 		});
@@ -338,10 +321,9 @@ public class XMLTextDocumentService implements TextDocumentService {
 
 	@Override
 	public CompletableFuture<List<Either<Command, CodeAction>>> codeAction(CodeActionParams params) {
-		return computeAsync((monitor) -> {
+		return computeAsync((cancelChecker) -> {
 			String uri = params.getTextDocument().getUri();
-			TextDocument document = getDocument(uri);
-			DOMDocument xmlDocument = getXMLDocument(document);
+			DOMDocument xmlDocument = getXMLDocument(params.getTextDocument().getUri(), cancelChecker);
 			return getXMLLanguageService()
 					.doCodeActions(params.getContext(), params.getRange(), xmlDocument, getFormattingSettings(uri)) //
 					.stream() //
@@ -350,7 +332,7 @@ public class XMLTextDocumentService implements TextDocumentService {
 							Either<Command, CodeAction> e = Either.forRight(ca);
 							return e;
 						} else {
-							List<Object> arguments = Arrays.asList(uri, document.getVersion(),
+							List<Object> arguments = Arrays.asList(uri, xmlDocument.getTextDocument().getVersion(),
 									ca.getEdit().getDocumentChanges().get(0).getLeft().getEdits());
 							Command command = new Command(ca.getTitle(), "_xml.applyCodeAction", arguments);
 							Either<Command, CodeAction> e = Either.forLeft(command);
@@ -395,39 +377,30 @@ public class XMLTextDocumentService implements TextDocumentService {
 		if (!documents.isEmpty()) {
 			xmlLanguageServer.schedule(() -> {
 				documents.forEach(document -> {
-					String uri = document.getUri();
-					int version = document.getVersion();
-					doTriggerValidation(uri, version, monitor);
+					try {
+						CancelChecker cancelChecker = new TextDocumentVersionChecker(document, document.getVersion());
+						validate(document, cancelChecker);
+					} catch (CancellationException e) {
+						// Ignore the error and continue to validate other documents
+					}
 				});
 			}, 500, TimeUnit.MILLISECONDS);
 		}
 	}
 
-	private void triggerValidation(String uri, int version) {
-		if (future != null && !future.isCancelled()) {
-			future.cancel(true);
-		}
-		if (monitor != null) {
-			monitor.setCanceled(true);
-		}
-		monitor = new BasicCancelChecker();
-		triggerValidation(uri, version, monitor);
-	}
-
-	private void triggerValidation(String uri, int version, CancelChecker monitor) {
-		future = xmlLanguageServer.schedule(() -> {
-			doTriggerValidation(uri, version, monitor);
+	private void triggerValidationFor(TextDocument document) {
+		CancelChecker cancelChecker = new TextDocumentVersionChecker(document, document.getVersion());
+		xmlLanguageServer.schedule(() -> {
+			validate(document, cancelChecker);
 		}, 500, TimeUnit.MILLISECONDS);
 	}
 
-	private void doTriggerValidation(String uri, int version, CancelChecker monitor) {
-		TextDocument currDocument = getDocument(uri);
-		if (currDocument != null && currDocument.getVersion() == version) {
-			DOMDocument xmlDocument = getXMLDocument(currDocument);
-			getXMLLanguageService().publishDiagnostics(xmlDocument,
-					params -> xmlLanguageServer.getLanguageClient().publishDiagnostics(params),
-					(u, v) -> triggerValidation(u, v), monitor, sharedSettings.validationSettings);
-		}
+	private void validate(TextDocument document, CancelChecker cancelChecker) throws CancellationException {
+		cancelChecker.checkCanceled();
+		DOMDocument xmlDocument = getXMLDocument(document);
+		getXMLLanguageService().publishDiagnostics(xmlDocument,
+				params -> xmlLanguageServer.getLanguageClient().publishDiagnostics(params),
+				(doc) -> triggerValidationFor(doc), sharedSettings.validationSettings, cancelChecker);
 	}
 
 	private XMLLanguageService getXMLLanguageService() {
@@ -459,7 +432,7 @@ public class XMLTextDocumentService implements TextDocumentService {
 	}
 
 	public XMLValidationSettings getValidationSettings() {
-		
+
 		return sharedSettings.validationSettings;
 	}
 

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/commons/LanguageModelCache.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/commons/LanguageModelCache.java
@@ -13,27 +13,29 @@ package org.eclipse.lsp4xml.commons;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
+import java.util.concurrent.CancellationException;
+import java.util.function.BiFunction;
 
 import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 
 /**
  * Language model cache.
  * 
  * @see https://github.com/Microsoft/vscode/blob/master/extensions/json-language-features/server/src/languageModelCache.ts
  *
- * @param <T>
+ * @param <T> model type (ex : DOMDocument for XML).
  */
 public class LanguageModelCache<T> {
 
 	private final Map<String, LanguageModeInfo> languageModels;
-	private final Function<TextDocument, T> parse;
+	private final BiFunction<TextDocument, CancelChecker, T> parse;
 	private final ITextDocumentFactory documentFactory;
 
 	class LanguageModeInfo {
 
-		public final int version;
-		public final String languageId;
+		public int version;
+		public String languageId;
 		public long cTime;
 		public T languageModel;
 
@@ -43,10 +45,34 @@ public class LanguageModelCache<T> {
 			this.languageId = languageId;
 			this.cTime = cTime;
 		}
+
+		/**
+		 * Returns true if the version and language id tuple matches or is newer than
+		 * the last processed version.
+		 * 
+		 * @param version    the version to check
+		 * @param languageId the language id to check
+		 * @return true if the version and language id tuple matches or is newer than
+		 *         the last processed version.
+		 */
+		public boolean isCurrent(int version, String languageId) {
+			if (this.version > version) {
+				// Stop the process because the given version is older than the cached model
+				// version
+				// This case comes from when an older request processed after a newer one
+				throw new CancellationException(
+						"The version '" + version + "' is older than the cached model version '" + this.version + "'.");
+			}
+			if (this.version == version && Objects.equals(languageId, this.languageId)) {
+				cTime = System.currentTimeMillis();
+				return true;
+			}
+			return false;
+		}
 	}
 
 	public LanguageModelCache(int maxEntries, int cleanupIntervalTimeInSec, ITextDocumentFactory documentFactory,
-			Function<TextDocument, T> parse) {
+			BiFunction<TextDocument, CancelChecker, T> parse) {
 		this.languageModels = new HashMap<>();
 		this.parse = parse;
 		this.documentFactory = documentFactory;
@@ -56,37 +82,57 @@ public class LanguageModelCache<T> {
 		int version = document.getVersion();
 		String languageId = document.getLanguageId();
 		String uri = document.getUri();
-		T languageModel = getLanguageModel(version, languageId, uri);
-		if (languageModel != null) {
-			return languageModel;
-		}
-		return parseAndGet(document, version, languageId, uri);
-	}
+		// get the language model information
+		LanguageModeInfo languageModelInfo = getLanguageModelInfo(uri);
 
-	private T getLanguageModel(int version, String languageId, String uri) {
-		LanguageModeInfo languageModelInfo = languageModels.get(uri);
-		if (languageModelInfo != null && languageModelInfo.version == version
-				&& Objects.equals(languageId, languageModelInfo.languageId)) {
-			languageModelInfo.cTime = System.currentTimeMillis();
+		if (languageModelInfo.isCurrent(version, languageId)) {
+			// The language model checks the current version, returns the cached model (ex:
+			// DOMDocument instance)
 			return languageModelInfo.languageModel;
 		}
-		return null;
+
+		// Parse the model (ex: DOM document) from the given text document.
+		synchronized (languageModelInfo) {
+			if (languageModelInfo.isCurrent(version, languageId)) {
+				return languageModelInfo.languageModel;
+			}
+			TextDocument textDocument = document instanceof TextDocument ? (TextDocument) document
+					: documentFactory.createDocument(document);
+			languageModelInfo.languageModel = parse.apply(textDocument,
+					new TextDocumentVersionChecker(textDocument, version));
+			languageModelInfo.version = version;
+			languageModelInfo.languageId = languageId;
+		}
+		return languageModelInfo.languageModel;
 	}
 
-	private synchronized T parseAndGet(TextDocumentItem document, int version, String languageId, String uri) {
-		T languageModel = getLanguageModel(version, languageId, uri);
-		if (languageModel != null) {
-			return languageModel;
+	/**
+	 * Returns the language model information for the given uri
+	 * 
+	 * @param uri document uri
+	 * @return the language model information for the given uri
+	 */
+	private LanguageModeInfo getLanguageModelInfo(String uri) {
+		LanguageModeInfo languageModelInfo = languageModels.get(uri);
+		if (languageModelInfo != null) {
+			return languageModelInfo;
 		}
-		TextDocument textDocument = document instanceof TextDocument ? (TextDocument) document
-				: documentFactory.createDocument(document);
-		languageModel = parse.apply(textDocument);
-		languageModels.put(uri, new LanguageModeInfo(languageModel, version, languageId, System.currentTimeMillis()));
-		return languageModel;
+		// The information doesn't exists, create it
+		synchronized (languageModels) {
+			languageModelInfo = languageModels.get(uri);
+			if (languageModelInfo != null) {
+				return languageModelInfo;
+			}
+			languageModelInfo = new LanguageModeInfo(null, -1, null, -1);
+			languageModels.put(uri, languageModelInfo);
+		}
+		return languageModelInfo;
 	}
 
 	public void onDocumentRemoved(String uri) {
-		languageModels.remove(uri);
+		synchronized (languageModels) {
+			languageModels.remove(uri);
+		}
 	}
 
 }

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/commons/TextDocumentVersionChecker.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/commons/TextDocumentVersionChecker.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.commons;
+
+import java.util.concurrent.CancellationException;
+
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+
+/**
+ * A {@link CancelChecker} implementation to throw a
+ * {@link CancellationException} when version of {@link TextDocument} changed.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class TextDocumentVersionChecker implements CancelChecker {
+
+	private final TextDocument textDocument;
+
+	private final int version;
+
+	public TextDocumentVersionChecker(TextDocument textDocument, int version) {
+		this.textDocument = textDocument;
+		this.version = version;
+	}
+
+	@Override
+	public void checkCanceled() {
+		if (textDocument.getVersion() != version) {
+			// the text document version has changed
+			throw new CancellationException("Text document version '" + version + "' has changed to version '"
+					+ textDocument.getVersion() + ".");
+		}
+	}
+
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLCompletions.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLCompletions.java
@@ -28,6 +28,7 @@ import org.eclipse.lsp4j.InsertTextFormat;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4xml.commons.BadLocationException;
 import org.eclipse.lsp4xml.commons.TextDocument;
 import org.eclipse.lsp4xml.customservice.AutoCloseTagResponse;
@@ -64,7 +65,7 @@ public class XMLCompletions {
 	}
 
 	public CompletionList doComplete(DOMDocument xmlDocument, Position position,
-			SharedSettings settings) {
+			SharedSettings settings, CancelChecker cancelChecker) {
 		CompletionResponse completionResponse = new CompletionResponse();
 		CompletionRequest completionRequest = null;
 		try {
@@ -90,6 +91,7 @@ public class XMLCompletions {
 		completionRequest.setCurrentAttributeName(null);
 		TokenType token = scanner.scan();
 		while (token != TokenType.EOS && scanner.getTokenOffset() <= offset) {
+			cancelChecker.checkCanceled();
 			switch (token) {
 			case StartTagOpen:
 				if (scanner.getTokenEnd() == offset) {
@@ -320,7 +322,7 @@ public class XMLCompletions {
 		return true;
 	}
 
-	public AutoCloseTagResponse doTagComplete(DOMDocument xmlDocument, Position position) {
+	public AutoCloseTagResponse doTagComplete(DOMDocument xmlDocument, Position position, CancelChecker cancelChecker) {
 		int offset;
 		try {
 			offset = xmlDocument.offsetAt(position);

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLFoldings.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLFoldings.java
@@ -25,6 +25,7 @@ import java.util.regex.Pattern;
 import org.eclipse.lsp4j.FoldingRange;
 import org.eclipse.lsp4j.FoldingRangeCapabilities;
 import org.eclipse.lsp4j.FoldingRangeKind;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4xml.commons.BadLocationException;
 import org.eclipse.lsp4xml.commons.TextDocument;
 import org.eclipse.lsp4xml.dom.parser.Scanner;
@@ -58,7 +59,7 @@ class XMLFoldings {
 		}
 	}
 
-	public List<FoldingRange> getFoldingRanges(TextDocument document, FoldingRangeCapabilities context) {		
+	public List<FoldingRange> getFoldingRanges(TextDocument document, FoldingRangeCapabilities context, CancelChecker cancelChecker) {		
 		Scanner scanner = XMLScanner.createScanner(document.getText());
 		TokenType token = scanner.scan();
 		List<FoldingRange> ranges = new ArrayList<>();
@@ -69,6 +70,7 @@ class XMLFoldings {
 
 		try {
 			while (token != TokenType.EOS) {
+				cancelChecker.checkCanceled();
 				switch (token) {
 				case StartTag: {
 					String tagName = scanner.getTokenText();

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLHighlighting.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLHighlighting.java
@@ -24,12 +24,14 @@ import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4xml.commons.BadLocationException;
 import org.eclipse.lsp4xml.dom.DOMDocument;
 import org.eclipse.lsp4xml.dom.DOMElement;
 import org.eclipse.lsp4xml.dom.DOMNode;
 import org.eclipse.lsp4xml.dom.parser.TokenType;
 import org.eclipse.lsp4xml.services.extensions.XMLExtensionsRegistry;
+
 /**
  * XML highlighting support.
  *
@@ -44,7 +46,8 @@ class XMLHighlighting {
 		this.extensionsRegistry = extensionsRegistry;
 	}
 
-	public List<DocumentHighlight> findDocumentHighlights(DOMDocument xmlDocument, Position position) {
+	public List<DocumentHighlight> findDocumentHighlights(DOMDocument xmlDocument, Position position,
+			CancelChecker cancelChecker) {
 		int offset = -1;
 		try {
 			offset = xmlDocument.offsetAt(position);
@@ -83,7 +86,8 @@ class XMLHighlighting {
 		} else if (node.isElement()) {
 			DOMElement element = (DOMElement) node;
 			startTagRange = getTagNameRange(TokenType.StartTag, node.getStart(), xmlDocument);
-			endTagRange = element.hasEndTag() ? getTagNameRange(TokenType.EndTag, element.getEndTagOpenOffset(), xmlDocument)
+			endTagRange = element.hasEndTag()
+					? getTagNameRange(TokenType.EndTag, element.getEndTagOpenOffset(), xmlDocument)
 					: null;
 			if (doesTagCoverPosition(startTagRange, endTagRange, position)) {
 				return getHighlightsList(startTagRange, endTagRange);

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLHover.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLHover.java
@@ -16,6 +16,7 @@ import java.util.logging.Logger;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4xml.commons.BadLocationException;
 import org.eclipse.lsp4xml.dom.DOMAttr;
 import org.eclipse.lsp4xml.dom.DOMDocument;
@@ -41,7 +42,7 @@ class XMLHover {
 		this.extensionsRegistry = extensionsRegistry;
 	}
 
-	public Hover doHover(DOMDocument xmlDocument, Position position) {
+	public Hover doHover(DOMDocument xmlDocument, Position position, CancelChecker cancelChecker) {
 		HoverRequest hoverRequest = null;
 		try {
 			hoverRequest = new HoverRequest(xmlDocument, position, extensionsRegistry);

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLLanguageService.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLLanguageService.java
@@ -14,7 +14,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import org.eclipse.lsp4j.CodeAction;
@@ -39,6 +38,7 @@ import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4xml.commons.BadLocationException;
 import org.eclipse.lsp4xml.commons.TextDocument;
+import org.eclipse.lsp4xml.commons.TextDocumentVersionChecker;
 import org.eclipse.lsp4xml.customservice.AutoCloseTagResponse;
 import org.eclipse.lsp4xml.dom.DOMDocument;
 import org.eclipse.lsp4xml.dom.DOMElement;
@@ -54,6 +54,14 @@ import org.eclipse.lsp4xml.utils.XMLPositionUtility;
  *
  */
 public class XMLLanguageService extends XMLExtensionsRegistry {
+
+	private static final CancelChecker NULL_CHECKER = new CancelChecker() {
+
+		@Override
+		public void checkCanceled() {
+			// Do nothing
+		}
+	};
 
 	private final XMLFormatter formatter;
 	private final XMLHighlighting highlighting;
@@ -88,38 +96,60 @@ public class XMLLanguageService extends XMLExtensionsRegistry {
 	}
 
 	public List<DocumentHighlight> findDocumentHighlights(DOMDocument xmlDocument, Position position) {
-		return highlighting.findDocumentHighlights(xmlDocument, position);
+		return findDocumentHighlights(xmlDocument, position, NULL_CHECKER);
+	}
+
+	public List<DocumentHighlight> findDocumentHighlights(DOMDocument xmlDocument, Position position,
+			CancelChecker cancelChecker) {
+		return highlighting.findDocumentHighlights(xmlDocument, position, cancelChecker);
 	}
 
 	public List<SymbolInformation> findSymbolInformations(DOMDocument xmlDocument) {
-		return symbolsProvider.findSymbolInformations(xmlDocument);
+		return findSymbolInformations(xmlDocument, NULL_CHECKER);
+	}
+
+	public List<SymbolInformation> findSymbolInformations(DOMDocument xmlDocument, CancelChecker cancelChecker) {
+		return symbolsProvider.findSymbolInformations(xmlDocument, cancelChecker);
 	}
 
 	public List<DocumentSymbol> findDocumentSymbols(DOMDocument xmlDocument) {
-		return symbolsProvider.findDocumentSymbols(xmlDocument);
+		return findDocumentSymbols(xmlDocument, NULL_CHECKER);
+	}
+
+	public List<DocumentSymbol> findDocumentSymbols(DOMDocument xmlDocument, CancelChecker cancelChecker) {
+		return symbolsProvider.findDocumentSymbols(xmlDocument, cancelChecker);
 	}
 
 	public CompletionList doComplete(DOMDocument xmlDocument, Position position, SharedSettings settings) {
-		return completions.doComplete(xmlDocument, position, settings);
+		return doComplete(xmlDocument, position, settings, NULL_CHECKER);
+	}
+
+	public CompletionList doComplete(DOMDocument xmlDocument, Position position, SharedSettings settings,
+			CancelChecker cancelChecker) {
+		return completions.doComplete(xmlDocument, position, settings, cancelChecker);
 	}
 
 	public Hover doHover(DOMDocument xmlDocument, Position position) {
-		return hover.doHover(xmlDocument, position);
+		return doHover(xmlDocument, position, NULL_CHECKER);
 	}
 
-	public List<Diagnostic> doDiagnostics(DOMDocument xmlDocument, CancelChecker monitor, XMLValidationSettings validationSettings) {
+	public Hover doHover(DOMDocument xmlDocument, Position position, CancelChecker cancelChecker) {
+		return hover.doHover(xmlDocument, position, cancelChecker);
+	}
+
+	public List<Diagnostic> doDiagnostics(DOMDocument xmlDocument, CancelChecker monitor,
+			XMLValidationSettings validationSettings) {
 		return diagnostics.doDiagnostics(xmlDocument, monitor, validationSettings);
 	}
 
 	public CompletableFuture<Path> publishDiagnostics(DOMDocument xmlDocument,
-			Consumer<PublishDiagnosticsParams> publishDiagnostics, BiConsumer<String, Integer> triggerValidation,
-			CancelChecker monitor, XMLValidationSettings validationSettings) {
+			Consumer<PublishDiagnosticsParams> publishDiagnostics, Consumer<TextDocument> triggerValidation,
+			XMLValidationSettings validationSettings, CancelChecker monitor) {
 		String uri = xmlDocument.getDocumentURI();
-		int version = xmlDocument.getTextDocument().getVersion();
+		TextDocument document = xmlDocument.getTextDocument();
 		try {
 			List<Diagnostic> diagnostics = this.doDiagnostics(xmlDocument, monitor, validationSettings);
 			monitor.checkCanceled();
-			
 			publishDiagnostics.accept(new PublishDiagnosticsParams(uri, diagnostics));
 			return null;
 		} catch (CacheResourceDownloadingException e) {
@@ -140,7 +170,7 @@ public class XMLLanguageService extends XMLExtensionsRegistry {
 					}) //
 					.thenAccept((path) -> {
 						if (path != null) {
-							triggerValidation.accept(uri, version);
+							triggerValidation.accept(document);
 						}
 					});
 			return e.getFuture();
@@ -157,8 +187,13 @@ public class XMLLanguageService extends XMLExtensionsRegistry {
 		publishDiagnostics.accept(new PublishDiagnosticsParams(uri, diagnostics));
 	}
 
-	public List<FoldingRange> getFoldingRanges(TextDocument document, FoldingRangeCapabilities context) {
-		return foldings.getFoldingRanges(document, context);
+	public List<FoldingRange> getFoldingRanges(DOMDocument xmlDocument, FoldingRangeCapabilities context) {
+		return getFoldingRanges(xmlDocument, context, NULL_CHECKER);
+	}
+
+	public List<FoldingRange> getFoldingRanges(DOMDocument xmlDocument, FoldingRangeCapabilities context,
+			CancelChecker cancelChecker) {
+		return foldings.getFoldingRanges(xmlDocument.getTextDocument(), context, cancelChecker);
 	}
 
 	public WorkspaceEdit doRename(DOMDocument xmlDocument, Position position, String newText) {
@@ -184,17 +219,21 @@ public class XMLLanguageService extends XMLExtensionsRegistry {
 	}
 
 	public AutoCloseTagResponse doTagComplete(DOMDocument xmlDocument, Position position) {
-		return completions.doTagComplete(xmlDocument, position);
+		return doTagComplete(xmlDocument, position, NULL_CHECKER);
 	}
 
-	public AutoCloseTagResponse doAutoClose(DOMDocument xmlDocument, Position position) {
+	public AutoCloseTagResponse doTagComplete(DOMDocument xmlDocument, Position position, CancelChecker cancelChecker) {
+		return completions.doTagComplete(xmlDocument, position, cancelChecker);
+	}
+
+	public AutoCloseTagResponse doAutoClose(DOMDocument xmlDocument, Position position, CancelChecker cancelChecker) {
 		try {
 			int offset = xmlDocument.offsetAt(position);
 			String text = xmlDocument.getText();
 			if (offset > 0) {
 				char c = text.charAt(offset - 1);
 				if (c == '>' || c == '/') {
-					return doTagComplete(xmlDocument, position);
+					return doTagComplete(xmlDocument, position, cancelChecker);
 				}
 			}
 			return null;
@@ -202,4 +241,5 @@ public class XMLLanguageService extends XMLExtensionsRegistry {
 			return null;
 		}
 	}
+
 }

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/XMLAssert.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/XMLAssert.java
@@ -121,13 +121,14 @@ public class XMLAssert {
 	public static void testCompletionFor(XMLLanguageService xmlLanguageService, String value, String catalogPath,
 			Consumer<XMLLanguageService> customConfiguration, String fileURI, Integer expectedCount,
 			CompletionSettings completionSettings, CompletionItem... expectedItems) throws BadLocationException {
-		testCompletionFor(xmlLanguageService, value, catalogPath, customConfiguration, fileURI, expectedCount, completionSettings, new XMLFormattingOptions(4, true), expectedItems);
+		testCompletionFor(xmlLanguageService, value, catalogPath, customConfiguration, fileURI, expectedCount,
+				completionSettings, new XMLFormattingOptions(4, true), expectedItems);
 	}
 
 	public static void testCompletionFor(XMLLanguageService xmlLanguageService, String value, String catalogPath,
 			Consumer<XMLLanguageService> customConfiguration, String fileURI, Integer expectedCount,
-			CompletionSettings completionSettings, XMLFormattingOptions formattingSettings, CompletionItem... expectedItems)
-			throws BadLocationException {
+			CompletionSettings completionSettings, XMLFormattingOptions formattingSettings,
+			CompletionItem... expectedItems) throws BadLocationException {
 		int offset = value.indexOf('|');
 		value = value.substring(0, offset) + value.substring(offset + 1);
 
@@ -205,7 +206,7 @@ public class XMLAssert {
 			Assert.assertEquals(expected.getFilterText(), match.getFilterText());
 		}
 
-		if(expected.getDetail() != null) {
+		if (expected.getDetail() != null) {
 			Assert.assertEquals(expected.getDetail(), match.getDetail());
 		}
 
@@ -251,7 +252,7 @@ public class XMLAssert {
 		DOMDocument htmlDoc = DOMParser.getInstance().parse(document, ls.getResolverExtensionManager());
 
 		AutoCloseTagResponse response = ls.doTagComplete(htmlDoc, position);
-		if(expected == null) {
+		if (expected == null) {
 			Assert.assertNull(response);
 			return;
 		}
@@ -287,7 +288,7 @@ public class XMLAssert {
 		}
 		testDiagnosticsFor(xml, catalogPath, configuration, fileURI, filter, settings, expected);
 	}
-	
+
 	public static void testDiagnosticsFor(String xml, String catalogPath, Consumer<XMLLanguageService> configuration,
 			String fileURI, boolean filter, ContentModelSettings settings, Diagnostic... expected) {
 		TextDocument document = new TextDocument(xml, fileURI != null ? fileURI : "test.xml");
@@ -305,7 +306,7 @@ public class XMLAssert {
 
 		List<Diagnostic> actual = xmlLanguageService.doDiagnostics(xmlDocument, () -> {
 		}, settings.getValidation());
-		if(expected == null) {
+		if (expected == null) {
 			assertTrue(actual.isEmpty());
 			return;
 		}
@@ -319,7 +320,7 @@ public class XMLAssert {
 	public static void assertDiagnostics(List<Diagnostic> actual, List<Diagnostic> expected, boolean filter) {
 		List<Diagnostic> received = actual;
 		final boolean filterMessage;
-		if(expected != null && !expected.isEmpty() && !StringUtils.isEmpty(expected.get(0).getMessage())) {
+		if (expected != null && !expected.isEmpty() && !StringUtils.isEmpty(expected.get(0).getMessage())) {
 			filterMessage = true;
 		} else {
 			filterMessage = false;
@@ -328,7 +329,7 @@ public class XMLAssert {
 			received = actual.stream().map(d -> {
 				Diagnostic simpler = new Diagnostic(d.getRange(), "");
 				simpler.setCode(d.getCode());
-				if(filterMessage) {
+				if (filterMessage) {
 					simpler.setMessage(d.getMessage());
 				}
 				return simpler;
@@ -346,7 +347,8 @@ public class XMLAssert {
 		return d(startLine, startCharacter, startLine, endCharacter, code);
 	}
 
-	public static Diagnostic d(int startLine, int startCharacter, int endLine, int endCharacter, IXMLErrorCode code, String message) {
+	public static Diagnostic d(int startLine, int startCharacter, int endLine, int endCharacter, IXMLErrorCode code,
+			String message) {
 		// Diagnostic on 1 line
 		return new Diagnostic(r(startLine, startCharacter, endLine, endCharacter), message, null, null, code.getCode());
 	}
@@ -395,11 +397,10 @@ public class XMLAssert {
 			XMLLanguageService languageService) {
 		CompletableFuture<Path> error = languageService.publishDiagnostics(xmlDocument, params -> {
 			actual.add(params);
-		}, (uri, version) -> {
+		}, (doc) -> {
 			// Retrigger validation
 			publishDiagnostics(xmlDocument, actual, languageService);
-		}, () -> {
-		}, null);
+		}, null, () -> {});
 
 		if (error != null) {
 			try {
@@ -427,11 +428,11 @@ public class XMLAssert {
 		SharedSettings settings = new SharedSettings();
 		settings.setFormattingSettings(new XMLFormattingOptions(4, false));
 		testCodeActionsFor(xml, diagnostic, catalogPath, settings, expected);
-		
+
 	}
 
-	public static void testCodeActionsFor(String xml, Diagnostic diagnostic, String catalogPath, SharedSettings sharedSettings,
-			CodeAction... expected) {
+	public static void testCodeActionsFor(String xml, Diagnostic diagnostic, String catalogPath,
+			SharedSettings sharedSettings, CodeAction... expected) {
 		TextDocument document = new TextDocument(xml.toString(), FILE_URI);
 
 		XMLLanguageService xmlLanguageService = new XMLLanguageService();
@@ -450,14 +451,12 @@ public class XMLAssert {
 		DOMDocument xmlDoc = DOMParser.getInstance().parse(document, xmlLanguageService.getResolverExtensionManager());
 
 		XMLFormattingOptions formattingSettings;
-		if(sharedSettings != null && sharedSettings.formattingSettings != null) {
+		if (sharedSettings != null && sharedSettings.formattingSettings != null) {
 			formattingSettings = sharedSettings.formattingSettings;
-		}
-		else {
+		} else {
 			formattingSettings = new XMLFormattingOptions(4, false);
 		}
-		List<CodeAction> actual = xmlLanguageService.doCodeActions(context, range, xmlDoc,
-				formattingSettings);
+		List<CodeAction> actual = xmlLanguageService.doCodeActions(context, range, xmlDoc, formattingSettings);
 		assertCodeActions(actual, expected);
 	}
 

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/commons/LanguageModelCacheTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/commons/LanguageModelCacheTest.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.commons;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4xml.dom.DOMDocument;
+import org.eclipse.lsp4xml.dom.DOMParser;
+import org.eclipse.lsp4xml.utils.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test with language model cache
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class LanguageModelCacheTest {
+
+	@Test
+	public void testModelCache() {
+
+		LanguageModelCache<DOMDocument> cache = new LanguageModelCache<DOMDocument>(10, 60, new TextDocuments(),
+				(document, monitor) -> {
+					return DOMParser.getInstance().parse(document, null);
+				});
+
+		Set<DOMDocument> documents = new HashSet<DOMDocument>();
+
+		String text = IOUtils.convertStreamToString(LanguageModelCacheTest.class.getResourceAsStream("/xml/nasa.xml"));
+		int version = 0;
+
+		AtomicBoolean hasCancellationException = new AtomicBoolean(false);
+
+		// Create 100 threads which get the nasa.xml file from the cache
+		List<Thread> threads = new ArrayList<>();
+		for (int i = 0; i < 100; i++) {
+
+			final TextDocumentItem document = new TextDocumentItem();
+			document.setLanguageId("xml");
+			document.setUri("test.xml");
+			document.setText(text);
+
+			if (i % 20 == 0) {
+				document.setVersion(version++);
+			}
+			Thread t = new Thread(() -> {
+				try {
+					// get DOM document from the cache and parse it if needed
+					DOMDocument dom = cache.get(document);
+					documents.add(dom);
+				} catch (CancellationException e) {
+					// This exception occurs when document version is older than cache model version
+					hasCancellationException.set(true);
+				}
+			});
+			threads.add(t);
+		}
+
+		// Execute the threads
+		for (Thread thread : threads) {
+			thread.start();
+		}
+
+		// Wait for all processes of the threads
+		for (Thread thread : threads) {
+			try {
+				thread.join();
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+
+		Assert.assertTrue("Has older version than model cache version", hasCancellationException.get());
+		Assert.assertTrue("DOM document instances", documents.size() <= version);
+
+	}
+}

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/dom/DOMDocumentVersionCheckerTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/dom/DOMDocumentVersionCheckerTest.java
@@ -1,0 +1,105 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.dom;
+
+import java.util.concurrent.CancellationException;
+
+import org.eclipse.lsp4xml.commons.BadLocationException;
+import org.eclipse.lsp4xml.commons.TextDocument;
+import org.eclipse.lsp4xml.commons.TextDocumentVersionChecker;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test to stop parse of {@link DOMDocument} when current version is not
+ * synchronized with the version of {@link TextDocument}.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class DOMDocumentVersionCheckerTest {
+
+	@Test
+	public void stopDOMParsing() {
+
+		TextDocument textDocument = createTextDocument();
+		int version = 1;
+		textDocument.setVersion(version);
+
+		// text document version and checker version are synchronized -> parse should be
+		// done
+		CancellationException ex = null;
+		TextDocumentVersionChecker checker = new TextDocumentVersionChecker(textDocument, version);
+		try {
+			DOMParser.getInstance().parse(textDocument, null, true, checker);
+		} catch (CancellationException e) {
+			ex = e;
+		}
+		Assert.assertNull(ex);
+
+		// text document version and checker version are NOT synchronized -> parse
+		// should be stopped
+		ex = null;
+		version = 2;
+		textDocument.setVersion(version);
+		try {
+			DOMParser.getInstance().parse(textDocument, null, true, checker);
+		} catch (CancellationException e) {
+			ex = e;
+		}
+		Assert.assertNotNull(ex);
+
+		// text document version and checker version are synchronized -> parse should be
+		// done
+		ex = null;
+		checker = new TextDocumentVersionChecker(textDocument, version);
+		try {
+			DOMParser.getInstance().parse(textDocument, null, true, checker);
+		} catch (CancellationException e) {
+			ex = e;
+		}
+		Assert.assertNull(ex);
+	}
+
+	@Test
+	public void positionAt() throws BadLocationException {
+		TextDocument textDocument = createTextDocument();
+		int version = 1;
+		textDocument.setVersion(version);
+
+		TextDocumentVersionChecker checker = new TextDocumentVersionChecker(textDocument, version);
+		DOMDocument document = DOMParser.getInstance().parse(textDocument, null, true, checker);
+
+		// text document version and checker version are synchronized -> call of
+		// positionAt (which uses line tracker) should work
+		CancellationException ex = null;
+		try {
+			document.positionAt(0);
+		} catch (CancellationException e) {
+			ex = e;
+		}
+		Assert.assertNull(ex);
+
+		// text document version and checker version are NOT synchronized -> call of
+		// positionAt (which uses line tracker) should NOT work
+		ex = null;
+		textDocument.setVersion(++version);
+		try {
+			document.positionAt(0);
+		} catch (CancellationException e) {
+			ex = e;
+		}
+		Assert.assertNotNull(ex);
+	}
+
+	private static TextDocument createTextDocument() {
+		return new TextDocument("<root />", "nasa.xml");
+	}
+}

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLFoldingsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLFoldingsTest.java
@@ -17,6 +17,8 @@ import java.util.List;
 import org.eclipse.lsp4j.FoldingRange;
 import org.eclipse.lsp4j.FoldingRangeCapabilities;
 import org.eclipse.lsp4xml.commons.TextDocument;
+import org.eclipse.lsp4xml.dom.DOMDocument;
+import org.eclipse.lsp4xml.dom.DOMParser;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -222,12 +224,12 @@ public class XMLFoldingsTest {
 
 	private static void assertRanges(String[] lines, ExpectedIndentRange[] expected, String message, Integer nRanges) {
 		TextDocument document = new TextDocument(String.join("\n", lines), "test://foo/bar.json");
-
+		DOMDocument xmlDocument = DOMParser.getInstance().parse(document, null);
 		XMLLanguageService languageService = new XMLLanguageService();
 
 		FoldingRangeCapabilities context = new FoldingRangeCapabilities();
 		context.setRangeLimit(nRanges);
-		List<FoldingRange> actual = languageService.getFoldingRanges(document, context);
+		List<FoldingRange> actual = languageService.getFoldingRanges(xmlDocument, context);
 
 		List<ExpectedIndentRange> actualRanges = new ArrayList<>();
 		for (FoldingRange f : actual) {


### PR DESCRIPTION
The basic idea is to cancel:

LSP requests which are executed on each change of text editor like
symbol provider, highligtings, hover, closeTag, etc
parse of DOM Document
This cancel support will improve performance and memory too.

Signed-off-by: azerr <azerr@redhat.com>