### PR TITLE
Fix range formatting issues

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/DOMNode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/DOMNode.java
@@ -486,6 +486,17 @@ public abstract class DOMNode implements Node {
 		return getNodeType() == DOMNode.DTD_NOTATION_DECL;
 	}
 
+	public boolean isOwnerDocument() {
+		return getNodeType() == Node.DOCUMENT_NODE;
+	}
+
+	public boolean isChildOfOwnerDocument() {
+		if (parent == null) {
+			return false;
+		}
+		return parent.getNodeType() == Node.DOCUMENT_NODE;
+	}
+
 	public int getStart() {
 		return start;
 	}
@@ -649,6 +660,14 @@ public abstract class DOMNode implements Node {
 		List<DOMNode> children = parentNode.getChildren();
 		int previousIndex = children.indexOf(this) - 1;
 		return previousIndex >= 0 ? children.get(previousIndex) : null;
+	}
+
+	public DOMNode getPreviousNonTextSibling() {
+		DOMNode prev = getPreviousSibling();
+		while (prev != null && prev.isText()) {
+			prev = prev.getPreviousSibling();
+		}
+		return prev;
 	}
 
 	/*

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLFormatter.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLFormatter.java
@@ -34,8 +34,10 @@ import org.eclipse.lsp4xml.dom.DTDAttlistDecl;
 import org.eclipse.lsp4xml.dom.DTDDeclNode;
 import org.eclipse.lsp4xml.dom.DTDDeclParameter;
 import org.eclipse.lsp4xml.services.extensions.XMLExtensionsRegistry;
+import org.eclipse.lsp4xml.services.extensions.diagnostics.IDiagnosticsParticipant;
 import org.eclipse.lsp4xml.settings.XMLFormattingOptions;
 import org.eclipse.lsp4xml.utils.XMLBuilder;
+import org.eclipse.lsp4xml.utils.XMLPositionUtility;
 
 /**
  * XML formatter support.
@@ -44,323 +46,517 @@ import org.eclipse.lsp4xml.utils.XMLBuilder;
 class XMLFormatter {
 
 	private static final Logger LOGGER = Logger.getLogger(XMLFormatter.class.getName());
-
 	private final XMLExtensionsRegistry extensionsRegistry;
-	private DOMNode previousNode;
+
+	private static class XMLFormatterDocument {
+		private final TextDocument textDocument;
+		private final Range range;
+		private final XMLFormattingOptions options;
+
+		private int startOffset;
+		private int endOffset;
+		private DOMDocument fullDomDocument;
+		private DOMDocument rangeDomDocument;
+		private XMLBuilder xmlBuilder;
+		private int indentLevel;
+
+		/**
+		 * XML formatter document.
+		 */
+		public XMLFormatterDocument(TextDocument textDocument, Range range, XMLFormattingOptions options) {
+			this.textDocument = textDocument;
+			this.range = range;
+			this.options = options;
+		}
+
+		/**
+		 * Returns a List containing a single TextEdit, containing the newly formatted changes
+		 * of this.textDocument
+		 * @return List containing a single TextEdit
+		 * @throws BadLocationException
+		 */
+		public List<? extends TextEdit> format() throws BadLocationException {
+			this.fullDomDocument = DOMParser.getInstance().parse(textDocument.getText(), textDocument.getUri(), null,
+					false);
+
+			if (range != null) {
+				setupRangeFormatting(range);
+			} else {
+				setupFullFormatting(range);
+			}
+
+			this.indentLevel = getStartingIndentLevel();
+			format(this.rangeDomDocument);
+
+			List<? extends TextEdit> textEdits = getFormatTextEdit();
+			return textEdits;
+		}
+
+		private void setupRangeFormatting(Range range) throws BadLocationException {
+			int startOffset = this.textDocument.offsetAt(range.getStart());
+			int endOffset = this.textDocument.offsetAt(range.getEnd());
+
+			Position startPosition = this.textDocument.positionAt(startOffset);
+			Position endPosition = this.textDocument.positionAt(endOffset);
+			enlargePositionToGutters(startPosition, endPosition);
+
+			this.startOffset = this.textDocument.offsetAt(startPosition);
+			this.endOffset = this.textDocument.offsetAt(endPosition);
+
+			String fullText = this.textDocument.getText();
+			String rangeText = fullText.substring(this.startOffset, this.endOffset);
+
+			this.rangeDomDocument = DOMParser.getInstance().parse(rangeText, this.textDocument.getUri(), null, false);
+
+			if (containsTextWithinStartTag()) {
+				adjustOffsetToStartTag();
+				rangeText = fullText.substring(this.startOffset, this.endOffset);
+				this.rangeDomDocument = DOMParser.getInstance().parse(rangeText, this.textDocument.getUri(), null, false);
+			}	
+
+			this.xmlBuilder = new XMLBuilder(this.options, "", textDocument.lineDelimiter(startPosition.getLine()));
+		}
+
+		private boolean containsTextWithinStartTag() {
+
+			if (this.rangeDomDocument.getChildren().size() < 1) {
+				return false;
+			}
+
+			DOMNode firstChild = this.rangeDomDocument.getChild(0);
+			if (!firstChild.isText()) {
+				return false;
+			}
+
+			int tagContentOffset = firstChild.getStart();
+			int fullDocOffset = getFullOffsetFromRangeOffset(tagContentOffset);
+			DOMNode fullNode = this.fullDomDocument.findNodeAt(fullDocOffset);
+
+			if (!fullNode.isElement()) {
+				return false;
+			}
+			return ((DOMElement) fullNode).isInStartTag(fullDocOffset);
+		}
+
+		private void adjustOffsetToStartTag() throws BadLocationException {
+			int tagContentOffset = this.rangeDomDocument.getChild(0).getStart();
+			int fullDocOffset = getFullOffsetFromRangeOffset(tagContentOffset);
+			DOMNode fullNode = this.fullDomDocument.findNodeAt(fullDocOffset);
+			Position nodePosition = this.textDocument.positionAt(fullNode.getStart());
+			nodePosition.setCharacter(0);
+			this.startOffset = this.textDocument.offsetAt(nodePosition);
+		}
+
+		private void setupFullFormatting(Range range) throws BadLocationException {
+			this.startOffset = 0;
+			this.endOffset = textDocument.getText().length();
+			this.rangeDomDocument = this.fullDomDocument;
+
+			Position startPosition = textDocument.positionAt(startOffset);
+			this.xmlBuilder = new XMLBuilder(this.options, "", textDocument.lineDelimiter(startPosition.getLine()));
+		}
+
+		private void enlargePositionToGutters(Position start, Position end) throws BadLocationException {
+			start.setCharacter(0);
+
+			if (end.getCharacter() == 0 && end.getLine() > 0) {
+				end.setLine(end.getLine() - 1);
+			}
+
+			end.setCharacter(this.textDocument.lineText(end.getLine()).length());
+		}
+
+		private int getStartingIndentLevel() throws BadLocationException {
+
+			DOMNode startNode = this.fullDomDocument.findNodeAt(this.startOffset);
+
+			if (startNode.isOwnerDocument()) {
+				return 0;
+			}
+
+			DOMNode startNodeParent = startNode.getParentNode();
+
+			if (startNodeParent.isOwnerDocument()) {
+				return 0;
+			}
+
+			// the starting indent level is the parent's indent level + 1
+			int startNodeIndentLevel = getNodeIndentLevel(startNodeParent) + 1;
+			return startNodeIndentLevel;
+		}
+
+		private int getNodeIndentLevel(DOMNode node) throws BadLocationException {
+
+			Position nodePosition = this.textDocument.positionAt(node.getStart());
+			String textBeforeNode = this.textDocument.lineText(nodePosition.getLine()).substring(0,
+					nodePosition.getCharacter() + 1);
+
+			int spaceOrTab = getSpaceOrTabStartOfString(textBeforeNode);
+
+			if (options.isInsertSpaces()) {
+				return (spaceOrTab / this.options.getTabSize());
+			}
+			return spaceOrTab;
+		}
+
+		private int getSpaceOrTabStartOfString(String string) {
+			int i = 0;
+			int spaceOrTab = 0;
+			while (i < string.length() && (string.charAt(i) == ' ' || string.charAt(i) == '\t')) {
+				spaceOrTab++;
+				i++;
+			}
+			return spaceOrTab;
+		}
+
+		private int getFullOffsetFromRangeOffset(int rangeOffset) {
+			return rangeOffset + this.startOffset;
+		}
+
+		private DOMElement getFullDocElemFromRangeElem(DOMElement elemFromRangeDoc) {
+			int fullOffset = getFullOffsetFromRangeOffset(elemFromRangeDoc.getEnd());
+			DOMElement elemFromFullDoc = (DOMElement) this.fullDomDocument.findNodeAt(fullOffset);
+			return elemFromFullDoc;
+		}
+
+		private boolean startTagExistsInRangeDocument(DOMNode node) {
+			if (!node.isElement()) {
+				return false;
+			}
+
+			return ((DOMElement) node).getStartTagOpenOffset() != DOMNode.NULL_VALUE;
+		}
+
+		private boolean startTagExistsInFullDocument(DOMNode node) {
+			if (!node.isElement()) {
+				return false;
+			}
+
+			DOMElement elemFromFullDoc = getFullDocElemFromRangeElem((DOMElement) node);
+
+			if (elemFromFullDoc == null) {
+				return false;
+			}
+
+			return elemFromFullDoc.getStartTagOpenOffset() != DOMNode.NULL_VALUE;
+		}
+
+		private void format(DOMNode node) throws BadLocationException {
+
+			if (node.getNodeType() != DOMNode.DOCUMENT_NODE) {
+				boolean doLineFeed;
+				if (node.getOwnerDocument().isDTD()) {
+					doLineFeed = false;
+				} else {
+					doLineFeed = !(node.isComment() && ((DOMComment) node).isCommentSameLineEndTag())
+							&& (!node.isText() || (!((DOMText) node).isWhitespace() && ((DOMText) node).hasSiblings()));
+				}
+
+				if (this.indentLevel > 0 && doLineFeed) {
+					// add new line + indent
+					if (!node.isChildOfOwnerDocument() || node.getPreviousNonTextSibling() != null) {
+						this.xmlBuilder.linefeed();
+					}
+
+					if (!startTagExistsInRangeDocument(node) && startTagExistsInFullDocument(node)) {
+						DOMNode startNode = getFullDocElemFromRangeElem((DOMElement) node);
+						int currentIndentLevel = getNodeIndentLevel(startNode);
+						this.xmlBuilder.indent(currentIndentLevel);
+						this.indentLevel = currentIndentLevel;
+					} else {
+						this.xmlBuilder.indent(this.indentLevel);
+					}
+				}
+				// generate start element
+				if (node.isElement()) {
+					DOMElement element = (DOMElement) node;
+					String tag = element.getTagName();
+					if (element.hasEndTag() && !element.hasStartTag()) {
+						// bad element which have not start tag (ex: <\root>)
+						xmlBuilder.endElement(tag, element.isEndTagClosed());
+					} else {
+						xmlBuilder.startElement(tag, false);
+						if (element.hasAttributes()) {
+							// generate attributes
+							List<DOMAttr> attributes = element.getAttributeNodes();
+							if (attributes.size() == 1) {
+								DOMAttr singleAttribute = attributes.get(0);
+								xmlBuilder.addSingleAttribute(singleAttribute.getName(),
+										singleAttribute.getOriginalValue());
+							} else {
+								for (DOMAttr attr : attributes) {
+									xmlBuilder.addAttribute(attr, this.indentLevel);
+								}
+							}
+						}
+
+						if (element.isStartTagClosed()) {
+							xmlBuilder.closeStartElement();
+						}
+
+						boolean hasElements = false;
+						if (node.hasChildNodes()) {
+							// element has body
+							
+							// startElementClosed = true;
+							this.indentLevel++;
+							for (DOMNode child : node.getChildren()) {
+								boolean textElement = !child.isText();
+
+								hasElements = hasElements | textElement;
+
+								format(child);
+							}
+							this.indentLevel--;
+						}
+						if (element.hasEndTag()) {
+							if (hasElements) {
+								this.xmlBuilder.linefeed();
+								this.xmlBuilder.indent(this.indentLevel);
+							}
+							// end tag element is done, only if the element is closed
+							// the format, doesn't fix the close tag
+							if (element.hasEndTag() && element.getEndTagOpenOffset() <= this.endOffset) {
+								this.xmlBuilder.endElement(tag, element.isEndTagClosed());
+							} else {
+								this.xmlBuilder.selfCloseElement();
+							}
+						} else if (element.isSelfClosed()) {
+							this.xmlBuilder.selfCloseElement();
+
+						}
+					}
+					return;
+
+				} else if (node.isCDATA()) {
+					DOMCDATASection cdata = (DOMCDATASection) node;
+					this.xmlBuilder.startCDATA();
+					this.xmlBuilder.addContentCDATA(cdata.getData());
+					this.xmlBuilder.endCDATA();
+				} else if (node.isComment()) {
+					DOMComment comment = (DOMComment) node;
+					this.xmlBuilder.startComment(comment);
+					this.xmlBuilder.addContentComment(comment.getData());
+					this.xmlBuilder.endComment();
+					if (this.indentLevel == 0) {
+						this.xmlBuilder.linefeed();
+					}
+				} else if (node.isProcessingInstruction()) {
+					addPIToXMLBuilder(node, this.xmlBuilder);
+					if (this.indentLevel == 0) {
+						this.xmlBuilder.linefeed();
+					}
+				} else if (node.isProlog()) {
+					addPrologToXMLBuilder(node, this.xmlBuilder);
+					this.xmlBuilder.linefeed();
+				} else if (node.isText()) {
+					DOMText textNode = (DOMText) node;
+
+					// Generate content
+					String content = textNode.getData();
+					xmlBuilder.addContent(content, textNode.isWhitespace(), textNode.hasSiblings(),
+							textNode.getDelimiter(), this.indentLevel);
+					return;
+				} else if (node.isDoctype()) {
+					boolean isDTD = node.getOwnerDocument().isDTD();
+					DOMDocumentType documentType = (DOMDocumentType) node;
+					if (!isDTD) {
+						this.xmlBuilder.startDoctype();
+						List<DTDDeclParameter> params = documentType.getParameters();
+
+						for (DTDDeclParameter param : params) {
+							if (!documentType.isInternalSubset(param)) {
+								xmlBuilder.addParameter(param.getParameter());
+							} else {
+								xmlBuilder.startDoctypeInternalSubset();
+								xmlBuilder.linefeed();
+								// level + 1 since the 'level' value is the doctype tag's level
+								formatDTD(documentType, this.indentLevel + 1, this.endOffset, this.xmlBuilder);
+								xmlBuilder.linefeed();
+								xmlBuilder.endDoctypeInternalSubset();
+							}
+						}
+						if (documentType.isClosed()) {
+							xmlBuilder.endDoctype();
+						}
+						xmlBuilder.linefeed();
+					} else {
+						formatDTD(documentType, 0, this.endOffset, this.xmlBuilder);
+					}
+					return;
+				}
+			} else if (node.hasChildNodes()) {
+				// Other nodes kind like root
+				for (DOMNode child : node.getChildren()) {
+					format(child);
+				}
+			}
+		}
+
+		private static boolean formatDTD(DOMDocumentType doctype, int level, int end, XMLBuilder xmlBuilder) {
+			DOMNode previous = null;
+			for (DOMNode node : doctype.getChildren()) {
+				if (previous != null) {
+					xmlBuilder.linefeed();
+				}
+
+				xmlBuilder.indent(level);
+
+				if (node.isText()) {
+					xmlBuilder.addContent(((DOMText) node).getData().trim());
+				} else if (node.isComment()) {
+					DOMComment comment = (DOMComment) node;
+					xmlBuilder.startComment(comment);
+					xmlBuilder.addContentComment(comment.getData());
+					xmlBuilder.endComment();
+				} else if (node.isProcessingInstruction()) {
+					addPIToXMLBuilder(node, xmlBuilder);
+				} else if (node.isProlog()) {
+					addPrologToXMLBuilder(node, xmlBuilder);
+				} else {
+					boolean setEndBracketOnNewLine = false;
+					DTDDeclNode decl = (DTDDeclNode) node;
+					xmlBuilder.addDeclTagStart(decl);
+
+					if (decl.isDTDAttListDecl()) {
+						DTDAttlistDecl attlist = (DTDAttlistDecl) decl;
+						List<DTDAttlistDecl> internalDecls = attlist.getInternalChildren();
+
+						if (internalDecls == null) {
+							for (DTDDeclParameter param : decl.getParameters()) {
+								xmlBuilder.addParameter(param.getParameter());
+							}
+						} else {
+							boolean multipleInternalAttlistDecls = false;
+							List<DTDDeclParameter> params = attlist.getParameters();
+							DTDDeclParameter param;
+							for (int i = 0; i < params.size(); i++) {
+								param = params.get(i);
+								if (attlist.elementName.equals(param)) {
+									xmlBuilder.addParameter(param.getParameter());
+									if (attlist.getParameters().size() > 1) { // has parameters after elementName
+										xmlBuilder.linefeed();
+										xmlBuilder.indent(level + 1);
+										setEndBracketOnNewLine = true;
+										multipleInternalAttlistDecls = true;
+									}
+								} else {
+									if (multipleInternalAttlistDecls && i == 1) {
+										xmlBuilder.addUnindentedParameter(param.getParameter());
+									} else {
+										xmlBuilder.addParameter(param.getParameter());
+									}
+								}
+							}
+
+							for (DTDAttlistDecl attlistDecl : internalDecls) {
+								xmlBuilder.linefeed();
+								xmlBuilder.indent(level + 1);
+								params = attlistDecl.getParameters();
+								for (int i = 0; i < params.size(); i++) {
+									param = params.get(i);
+
+									if (i == 0) {
+										xmlBuilder.addUnindentedParameter(param.getParameter());
+									} else {
+										xmlBuilder.addParameter(param.getParameter());
+									}
+								}
+							}
+						}
+					} else {
+						for (DTDDeclParameter param : decl.getParameters()) {
+							xmlBuilder.addParameter(param.getParameter());
+						}
+					}
+					if (setEndBracketOnNewLine) {
+						xmlBuilder.linefeed();
+						xmlBuilder.indent(level);
+					}
+					if (decl.isClosed()) {
+						xmlBuilder.closeStartElement();
+					}
+				}
+				previous = node;
+			}
+			return true;
+		}
+
+		private List<? extends TextEdit> getFormatTextEdit() throws BadLocationException {
+			Position startPosition = this.textDocument.positionAt(this.startOffset);
+			Position endPosition = this.textDocument.positionAt(this.endOffset);
+			Range r = new Range(startPosition, endPosition);
+			List<TextEdit> edits = new ArrayList<>();
+			edits.add(new TextEdit(r, this.xmlBuilder.toString()));
+			return edits;
+		}
+
+		private static boolean isFirstChildNode(DOMNode node) {
+			return node.equals(node.getParentNode().getFirstChild());
+		}
+
+		private static boolean isPreviousSiblingNodeType(DOMNode node, short nodeType) {
+			DOMNode previousNode = node.getPreviousSibling();
+			return previousNode != null && previousNode.getNodeType() == nodeType;
+		}
+
+		private static void addPIToXMLBuilder(DOMNode node, XMLBuilder xml) {
+			DOMProcessingInstruction processingInstruction = (DOMProcessingInstruction) node;
+			xml.startPrologOrPI(processingInstruction.getTarget());
+
+			String content = processingInstruction.getData();
+			if (content.length() > 0) {
+				xml.addContentPI(content);
+			} else {
+				xml.addContent(" ");
+			}
+
+			xml.endPrologOrPI();
+		}
+
+		private static void addPrologToXMLBuilder(DOMNode node, XMLBuilder xml) {
+			DOMProcessingInstruction processingInstruction = (DOMProcessingInstruction) node;
+			xml.startPrologOrPI(processingInstruction.getTarget());
+			if (node.hasAttributes()) {
+				addAttributes(node, xml);
+			}
+			xml.endPrologOrPI();
+		}
+
+		/**
+		 * Will add all attributes, to the given builder, on a single line
+		 */
+		private static void addAttributes(DOMNode node, XMLBuilder xmlBuilder) {
+			List<DOMAttr> attrs = node.getAttributeNodes();
+			if (attrs == null) {
+				return;
+			}
+			for (DOMAttr attr : attrs) {
+				xmlBuilder.addAttributesOnSingleLine(attr, true);
+			}
+			xmlBuilder.appendSpace();
+		}
+	}
 
 	public XMLFormatter(XMLExtensionsRegistry extensionsRegistry) {
 		this.extensionsRegistry = extensionsRegistry;
 	}
 
-	public List<? extends TextEdit> format(TextDocument document, Range range, XMLFormattingOptions formattingOptions) {
+	/**
+	 * Returns a List containing a single TextEdit, containing the newly formatted changes
+	 * of the document.
+	 * @param textDocument document to perform formatting on
+	 * @param range specified range in which formatting will be done
+	 * @return List containing a TextEdit with formatting changes
+	 */
+	public List<? extends TextEdit> format(TextDocument textDocument, Range range,
+			XMLFormattingOptions formattingOptions) {
 		try {
-			// Compute start/end offset range
-			int start = -1;
-			int end = -1;
-			if (range == null) {
-				start = 0;
-				end = document.getText().length();
-			} else {
-				start = document.offsetAt(range.getStart());
-				end = document.offsetAt(range.getEnd());
-			}
-			Position startPosition = document.positionAt(start);
-			Position endPosition = document.positionAt(end);
-
-			// Parse the content to format to create an XML document with full data (CData,
-			// comments, etc)
-			String text = document.getText().substring(start, end);
-			DOMDocument doc = DOMParser.getInstance().parse(text, document.getUri(), null, false);
-
-			// Format the content
-			XMLBuilder xml = new XMLBuilder(formattingOptions, "", document.lineDelimiter(startPosition.getLine()));
-			format(doc, 0, end, xml);
-
-			// Returns LSP list of TextEdits
-			Range r = new Range(startPosition, endPosition);
-			List<TextEdit> edits = new ArrayList<>();
-			edits.add(new TextEdit(r, xml.toString()));
-			return edits;
-
+			XMLFormatterDocument formatterDocument = new XMLFormatterDocument(textDocument, range, formattingOptions);
+			return formatterDocument.format();
 		} catch (BadLocationException e) {
-			LOGGER.log(Level.SEVERE, "Formatting failed due to BadLocation from 'range' parameter", e);
+			LOGGER.log(Level.SEVERE, "Formatting failed due to BadLocation", e);
 		}
 		return null;
-	}
-
-	private void format(DOMNode node, int level, int end, XMLBuilder xml) {
-		
-		if (node.getNodeType() != DOMNode.DOCUMENT_NODE) {
-			boolean doLineFeed;
-			if(node.getOwnerDocument().isDTD()) {
-				doLineFeed = false;
-			} else {
-				doLineFeed = !(node.isComment() && ((DOMComment) node).isCommentSameLineEndTag())
-					&& (!node.isText() || (!((DOMText) node).isWhitespace() && ((DOMText) node).hasSiblings()));
-
-					//&& (!isPreviousSiblingNodeType(node, DOMNode.TEXT_NODE) || !((DOMText) node.getPreviousSibling()).endsWithNewLine())
-			}
-
-			if (level > 0 && doLineFeed) {
-				// add new line + indent
-				xml.linefeed();
-				xml.indent(level);
-			}
-			// generate start element
-			if (node.isElement()) {
-				DOMElement element = (DOMElement) node;
-				String tag = element.getTagName();
-				if (element.hasEndTag() && !element.hasStartTag()) {
-					// bad element which have not start tag (ex: <\root>)
-					xml.endElement(tag, element.isEndTagClosed());
-				} else {
-					xml.startElement(tag, false);
-					if (element.hasAttributes()) {
-						// generate attributes
-						List<DOMAttr> attributes = element.getAttributeNodes();
-						if (attributes.size() == 1) {
-							DOMAttr singleAttribute = attributes.get(0);
-							xml.addSingleAttribute(singleAttribute.getName(), singleAttribute.getOriginalValue());
-						} else {
-							for (DOMAttr attr : attributes) {
-								xml.addAttribute(attr, level);
-							}
-						}
-					}
-
-					if(element.isStartTagClosed()) {
-						xml.closeStartElement();	
-					}
-
-					boolean hasElements = false;
-					if (node.hasChildNodes()) {
-						// element has body
-						
-						
-						//startElementClosed = true;
-						level++;
-						for (DOMNode child : node.getChildren()) {
-							boolean textElement = !child.isText();
-
-							hasElements = hasElements | textElement;
-
-							format(child, level, end, xml);
-						}
-						level--;
-					}
-					if (element.hasEndTag()) {
-						if (hasElements) {
-							xml.linefeed();
-							xml.indent(level);
-						}
-						// end tag element is done, only if the element is closed
-						// the format, doesn't fix the close tag
-						if (element.hasEndTag() && element.getEndTagOpenOffset() <= end) {
-							xml.endElement(tag, element.isEndTagClosed());
-						} else {
-							xml.selfCloseElement();
-						}
-					} else if (element.isSelfClosed()) {
-						xml.selfCloseElement();
-						
-					}
-				}
-				return;
-
-			} else if (node.isCDATA()) {
-				DOMCDATASection cdata = (DOMCDATASection) node;
-				xml.startCDATA();
-				xml.addContentCDATA(cdata.getData());
-				xml.endCDATA();
-			} else if (node.isComment()) {
-				DOMComment comment = (DOMComment) node;
-				xml.startComment(comment);
-				xml.addContentComment(comment.getData());
-				xml.endComment();
-				if (level == 0) {
-					xml.linefeed();
-				}
-			} else if (node.isProcessingInstruction()) {
-				addPIToXMLBuilder(node, xml);
-				if (level == 0) {
-					xml.linefeed();
-				}
-			} else if (node.isProlog()) {
-				addPrologToXMLBuilder(node, xml);
-				xml.linefeed();
-			} else if (node.isText()) {
-				DOMText textNode = (DOMText) node;
-				
-				// Generate content
-				String content = textNode.getData();
-				xml.addContent(content, textNode.isWhitespace(), textNode.hasSiblings(), textNode.getDelimiter(), level);
-				return;
-			} else if (node.isDoctype()) {
-				boolean isDTD = node.getOwnerDocument().isDTD();
-				DOMDocumentType documentType = (DOMDocumentType) node;
-				if(!isDTD) {
-					xml.startDoctype();
-					List<DTDDeclParameter> params = documentType.getParameters();
-					for (DTDDeclParameter param : params) {
-						if(!documentType.isInternalSubset(param)) {
-							xml.addParameter(param.getParameter());
-						} else {
-							xml.startDoctypeInternalSubset();
-							xml.linefeed();
-							// level + 1 since the 'level' value is the doctype tag's level
-							formatDTD(documentType, level + 1, end, xml); 
-							xml.linefeed();
-							xml.endDoctypeInternalSubset();
-						}
-					}
-					if(documentType.isClosed()) {
-						xml.endDoctype();
-					}
-					xml.linefeed();
-				} else {
-					formatDTD(documentType, 0, end, xml);
-				}
-				return;
-			}
-		} else if (node.hasChildNodes()) {
-			// Other nodes kind like root
-			for (DOMNode child : node.getChildren()) {
-				format(child, level, end, xml);
-			}
-		}
-	}
-
-	private static boolean formatDTD(DOMDocumentType doctype, int level, int end, XMLBuilder xml) {
-		DOMNode previous = null;
-		for (DOMNode node : doctype.getChildren()) {
-			if(previous != null) {
-				xml.linefeed();
-			} 
-
-			xml.indent(level);
-			
-			if (node.isText()) {
-				xml.addContent(((DOMText)node).getData().trim());
-			} else if (node.isComment()) {
-				DOMComment comment = (DOMComment) node;
-				xml.startComment(comment);
-				xml.addContentComment(comment.getData());
-				xml.endComment();
-			} else if (node.isProcessingInstruction()) {
-				addPIToXMLBuilder(node, xml);
-			} else if (node.isProlog()) {
-				addPrologToXMLBuilder(node, xml);
-			} else {
-				boolean setEndBracketOnNewLine = false;
-				DTDDeclNode decl = (DTDDeclNode) node;
-				xml.addDeclTagStart(decl);
-
-				if (decl.isDTDAttListDecl()) {
-					DTDAttlistDecl attlist = (DTDAttlistDecl) decl;
-					List<DTDAttlistDecl> internalDecls = attlist.getInternalChildren();
-
-					if (internalDecls == null) {
-						for (DTDDeclParameter param : decl.getParameters()) {
-							xml.addParameter(param.getParameter());	
-						}
-					} else {
-						boolean multipleInternalAttlistDecls = false;
-						List<DTDDeclParameter> params = attlist.getParameters();
-						DTDDeclParameter param;
-						for(int i = 0; i < params.size(); i++) {
-							param = params.get(i);
-							if(attlist.elementName.equals(param)) {
-								xml.addParameter(param.getParameter());
-								if(attlist.getParameters().size() > 1) { //has parameters after elementName
-									xml.linefeed();
-									xml.indent(level + 1);
-									setEndBracketOnNewLine = true;
-									multipleInternalAttlistDecls = true;
-								}
-							} else {
-								if(multipleInternalAttlistDecls && i == 1) {
-									xml.addUnindentedParameter(param.getParameter());
-								} else {
-									xml.addParameter(param.getParameter());	
-								}
-							}
-						}
-
-						for (DTDAttlistDecl attlistDecl : internalDecls) {
-							xml.linefeed();
-							xml.indent(level + 1);
-							params = attlistDecl.getParameters();
-							for(int i = 0; i < params.size(); i++) {
-								param = params.get(i);
-								if(i == 0) {
-									xml.addUnindentedParameter(param.getParameter());
-								} else {
-									xml.addParameter(param.getParameter());	
-								}
-							}
-						}
-					}
-				} else {
-					for (DTDDeclParameter param : decl.getParameters()) {
-						xml.addParameter(param.getParameter());	
-					}
-				}
-				if(setEndBracketOnNewLine) {
-					xml.linefeed();
-					xml.indent(level);
-				}
-				if(decl.isClosed()) {
-					xml.closeStartElement();
-				}
-			}
-			previous = node;
-		}
-		return true;
-	}
-
-	private static boolean isFirstChildNode(DOMNode node) {
-		return node.equals(node.getParentNode().getFirstChild());
-	}
-
-	private static boolean isPreviousSiblingNodeType(DOMNode node, short nodeType) {
-		DOMNode previousNode = node.getPreviousSibling();
-		return previousNode != null && previousNode.getNodeType() == nodeType;
-	}
-
-	private static void addPIToXMLBuilder(DOMNode node, XMLBuilder xml) {
-		DOMProcessingInstruction processingInstruction = (DOMProcessingInstruction) node;
-		xml.startPrologOrPI(processingInstruction.getTarget());
-
-		String content = processingInstruction.getData();
-		if (content.length() > 0) {
-			xml.addContentPI(content);
-		} else {
-			xml.addContent(" ");
-		}
-
-		xml.endPrologOrPI();
-	}
-
-	private static void addPrologToXMLBuilder(DOMNode node, XMLBuilder xml) {
-		DOMProcessingInstruction processingInstruction = (DOMProcessingInstruction) node;
-		xml.startPrologOrPI(processingInstruction.getTarget());
-		if (node.hasAttributes()) {
-			addAttributes(node, xml);
-		}
-		xml.endPrologOrPI();
-	}
-
-	/**
-	 * Will add all attributes, to the given builder, on a single line
-	 */
-	private static void addAttributes(DOMNode node, XMLBuilder xml) {
-		List<DOMAttr> attrs = node.getAttributeNodes();
-		if(attrs == null) {
-			return;
-		}
-		for (DOMAttr attr : attrs) {
-			xml.addAttributesOnSingleLine(attr, true);
-		}
-		xml.appendSpace();
 	}
 }

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLFormatterTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLFormatterTest.java
@@ -119,6 +119,182 @@ public class XMLFormatterTest {
 	}
 
 	@Test
+	public void rangeChildrenFullSelection() throws BadLocationException {
+		String content =
+		"<licenses>\n" +
+		"  <license>\n" +
+		"    <name>License Name</name>\n" +
+		"|           <url>abcdefghijklmnop</url>\n" +
+		"            <distribution>repo</distribution>|\n" +
+		"  </license>\n" +
+		"</licenses>";
+
+		String expected =
+		"<licenses>\n" +
+		"  <license>\n" +
+		"    <name>License Name</name>\n" +
+		"    <url>abcdefghijklmnop</url>\n" +
+		"    <distribution>repo</distribution>\n" +
+		"  </license>\n" +
+		"</licenses>";
+		
+		format(content, expected);
+	}
+
+	@Test
+	public void rangeChildrenPartialSelection() throws BadLocationException {
+		String content =
+		"<licenses>\n" +
+		"  <license>\n" +
+		"  <name>Licen|se Name</name>\n" +
+		"              <url>abcdefghijklmnop</url>\n" +
+		"              <distribution>repo</distribution>|\n" +
+		"  </license>\n" +
+		"</licenses>";
+
+		String expected =
+		"<licenses>\n" +
+		"  <license>\n" +
+		"    <name>License Name</name>\n" +
+		"    <url>abcdefghijklmnop</url>\n" +
+		"    <distribution>repo</distribution>\n" +
+		"  </license>\n" +
+		"</licenses>";
+		
+		format(content, expected);
+	}
+
+	@Test
+	public void rangeSelectAll() throws BadLocationException {
+		String content = 
+		"<licenses>\n" +
+		"                                            <license>\n" +
+		"                        <name>License Name</name>\n" +
+		"        <url>abcdefghijklmnop</url>\n" +
+		"        <distribution>repo</distribution>\n" +
+		"                                        </license>\n" +
+		"                                                                </licenses>";
+
+		String expected =
+		"<licenses>\n" +
+		"  <license>\n" +
+		"    <name>License Name</name>\n" +
+		"    <url>abcdefghijklmnop</url>\n" +
+		"    <distribution>repo</distribution>\n" +
+		"  </license>\n" +
+		"</licenses>";
+		
+		format(content, expected);
+	}
+
+	@Test
+	public void rangeSelectOnlyPartialStartTagAndChildren() throws BadLocationException {
+		String content = 
+		"<licenses>\n" +
+		"                                 <lice|nse>\n" +
+		"                <name>License Name</name>\n" +
+		"                        <url>abcdefghijklmnop</url>\n" +
+		"            <distribution>repo</distribution>|\n" +
+		"  </license>\n" +
+		"</licenses>";
+
+		String expected =
+		"<licenses>\n" +
+		"  <license>\n" +
+		"    <name>License Name</name>\n" +
+		"    <url>abcdefghijklmnop</url>\n" +
+		"    <distribution>repo</distribution>\n" +
+		"  </license>\n" +
+		"</licenses>";
+		
+		format(content, expected);
+	}
+
+	@Test
+	public void rangeSelectOnlyFullStartTagAndChildren() throws BadLocationException {
+		String content = 
+		"<licenses>\n" +
+		"                                 |<license>\n" +
+		"                <name>License Name</name>\n" +
+		"                        <url>abcdefghijklmnop</url>\n" +
+		"            <distribution>repo</distribution>|\n" +
+		"  </license>\n" +
+		"</licenses>";
+
+		String expected =
+		"<licenses>\n" +
+		"  <license>\n" +
+		"    <name>License Name</name>\n" +
+		"    <url>abcdefghijklmnop</url>\n" +
+		"    <distribution>repo</distribution>\n" +
+		"  </license>\n" +
+		"</licenses>";
+		
+		format(content, expected);
+	}
+
+	@Test
+	public void rangeSelectOnlyPartialEndTagAndChildren() throws BadLocationException {
+		String content = 
+		"<licenses>\n" +
+		"  <license>\n" +
+		"                <nam|e>License Name</name>\n" +
+		"                        <url>abcdefghijklmnop</url>\n" +
+		"            <distribution>repo</distribution>\n" +
+		"  </licen|se>\n" +
+		"</licenses>";
+
+		String expected =
+		"<licenses>\n" +
+		"  <license>\n" +
+		"    <name>License Name</name>\n" +
+		"    <url>abcdefghijklmnop</url>\n" +
+		"    <distribution>repo</distribution>\n" +
+		"  </license>\n" +
+		"</licenses>";
+		
+		format(content, expected);
+	}
+
+	@Test
+	public void rangeSelectOnlyFullEndTagAndChildren() throws BadLocationException {
+		String content = 
+		"<licenses>\n" +
+		"  <license>\n" +
+		"                <nam|e>License Name</name>\n" +
+		"                        <url>abcdefghijklmnop</url>\n" +
+		"            <distribution>repo</distribution>\n" +
+		"  </license>|\n" +
+		"</licenses>";
+
+		String expected =
+		"<licenses>\n" +
+		"  <license>\n" +
+		"    <name>License Name</name>\n" +
+		"    <url>abcdefghijklmnop</url>\n" +
+		"    <distribution>repo</distribution>\n" +
+		"  </license>\n" +
+		"</licenses>";
+		
+		format(content, expected);
+	}
+	
+	@Test
+	public void rangeSelectWithinText() throws BadLocationException {
+		String content = 
+		"<licenses>\n" +
+		"                <name>Lic|en|se</name>\n" +
+		"</licenses>";
+
+		String expected =
+		"<licenses>\n" +
+		"  <name>License</name>\n" +
+		"</licenses>";
+		
+		format(content, expected);
+	}
+
+	@Test
 	public void testProlog() throws BadLocationException {
 		String content = "<?xml version=   \"1.0\"       encoding=\"UTF-8\"  ?>" + lineSeparator();
 		String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>" + lineSeparator();
@@ -1727,6 +1903,93 @@ public class XMLFormatterTest {
 		format(content, expected, formattingOptions);
 	}
 
+	@Test
+	public void testAttributeNameValueTwoLines() throws BadLocationException {
+		String content = 
+			"<xml>\r\n" +
+			"  <a \r\n" +
+			"   |a             =         \"aa\"|>\r\n" +
+			"    <b></b>\r\n" +
+			"  </a>\r\n" +
+			"</xml>";
+		String expected = 
+			"<xml>\r\n" +
+			"  <a a=\"aa\">\r\n" +
+			"    <b></b>\r\n" +
+			"  </a>\r\n" +
+			"</xml>";
+		format(content, expected);
+	}
+
+	@Test
+	public void testAttributeNameValueMultipleLines() throws BadLocationException {
+		String content = 
+			"<xml>\r\n" +
+			"  <a \r\n" +
+			"  |a\r\n" +
+			"  =\r\n" +
+			"  \"aa\"\r\n" +
+			"  \r\n" +
+			"  >|\r\n" +
+			"    <b></b>\r\n" +
+			"  </a>\r\n" +
+			"</xml>";
+		String expected = 
+			"<xml>\r\n" +
+			"  <a a=\"aa\">\r\n" +
+			"    <b></b>\r\n" +
+			"  </a>\r\n" +
+			"</xml>";
+		format(content, expected);
+	}
+
+	@Test
+	public void testAttributeNameValueMultipleLinesWithChild() throws BadLocationException {
+		String content = 
+			"<xml>\r\n" +
+			"  <a \r\n" +
+			"   |a          =        \r\n" +
+			"   \r\n" +
+			"   \"aa\">|<b></b>\r\n" +
+			"  </a>\r\n" +
+			"</xml>";
+		String expected = 
+			"<xml>\r\n" +
+			"  <a a=\"aa\">\r\n" +
+			"    <b></b>\r\n" +
+			"  </a>\r\n" +
+			"</xml>";
+		format(content, expected);
+	}
+
+	@Test
+	public void testAttributeNameValueMultipleLinesWithChildrenSiblings() throws BadLocationException {
+		String content = 
+			"<xml>\r\n" +
+			"  <a \r\n" +
+			"  |a\r\n" +
+			"  =\r\n" +
+			"  \"aa\"\r\n" +
+			"  \r\n" +
+			"  >\r\n" +
+			"        <b>\r\n" +
+			"          <c></c>\r\n" +
+			"    </b>\r\n" +
+			"  </a>\r\n" +
+			"        <d></d>|\r\n" +
+			"</xml>";
+		String expected = 
+			"<xml>\r\n" +
+			"  <a a=\"aa\">\r\n" +
+			"    <b>\r\n" +
+			"      <c></c>\r\n" +
+			"    </b>\r\n" +
+			"  </a>\r\n" +
+			"  <d></d>\r\n" +
+			"</xml>";
+		format(content, expected);
+	}
+
 	@Test 
 	public void testPreserveNewlines() throws BadLocationException {
 		XMLFormattingOptions formattingOptions = createDefaultFormattingOptions();
@@ -1928,10 +2191,16 @@ public class XMLFormatterTest {
 		TextDocument document = new TextDocument(unformatted, uri);
 		XMLLanguageService languageService = new XMLLanguageService();
 		List<? extends TextEdit> edits = languageService.format(document, range, formattingOptions);
+		
 		String formatted = edits.stream().map(edit -> edit.getNewText()).collect(Collectors.joining(""));
-		if (rangeStart != -1 && rangeEnd != -1) {
-			formatted = unformatted.substring(0, rangeStart) + formatted
-					+ unformatted.substring(rangeEnd - 1, unformatted.length());
+
+		Range textEditRange = edits.get(0).getRange();
+		int textEditStartOffset = document.offsetAt(textEditRange.getStart());
+		int textEditEndOffset = document.offsetAt(textEditRange.getEnd()) + 1;
+
+		if (textEditStartOffset != -1 && textEditEndOffset != -1) {
+			formatted = unformatted.substring(0, textEditStartOffset) + formatted
+					+ unformatted.substring(textEditEndOffset - 1, unformatted.length());
 		}
 		
 		Assert.assertEquals(expected, formatted);


### PR DESCRIPTION
This PR fixes some problems with range formatting.


It is important to note that with this fix, the range of the highlighted region will have its start and end lines to be extended to the ends or the "gutters" of the document.

For example, this fix will consider this range:
![image](https://user-images.githubusercontent.com/20326645/59129361-9c020f80-893a-11e9-8fd4-1812ade3709d.png)

to be identical to this range:
![image](https://user-images.githubusercontent.com/20326645/59129372-a45a4a80-893a-11e9-8039-2ec819c94505.png)

The most significant change made in `XMLFormatter.java`, was the introduction to more instance variables (which are set to `null` when formatting is done).
Many methods in `XMLFormatter.java` rely on these instance variables. I am not entirely sure if this was a good idea in terms of design.

For both selection formatting and full document formatting, `this.fullDomDocument` and `this.rangeDomDocument` are set.

`this.fullDomDocument` -> the `DOMDocument` of the whole document
`this.rangeDomDocument` -> the `DOMDocument` for the part of the document within the formatting range

Note that for full document formatting, `this.fullDomDocument` and `this.rangeDomDocument` refer to the same `DOMDocument` object, because the formatting range is the whole document.

Note: This could have been implemented differently, see the last paragraph of this PR message.

The reason why selection formatting requires `this.fullDomDocument` is because selection formatting requires contextual information from the whole document, in order to determine the 
level of indentation. Selection formatting requires information about nodes in `this.fullDomDocument`, which do not exist in `this.rangeDomDocument`.

Since the nodes in `this.rangeDomDocument` is a subset of nodes in `this.fullDomDocument`, the only differences are that:
* The offsets for corresponding nodes will be different because offset 0 for `this.rangeDomDocument`, would be the start of the selected range, wheras offset 0 for `this.fullDomDocument` would be the start of the whole document.
        The method `getFullOffsetFromRangeOffset(int offset)` converts an offset from a node in `this.rangeDomDocument`, to an equivalent offset for nodes in `this.fullDomDocument`.
* Elements in `this.rangeDomDocument` may indicate that they do not have a starting or ending tag, even if the corresponding element in `this.fullDomDocument` has a starting and ending tag. For example, if the selected range contained only the end tag of an element, that corresponding element in `this.rangeDomDocument` believes that the element is missing a start tag, while the corresponding element in `this.fullDomDocument` knows that the element has both a start and end tag.


Simple cases that are tested to work:

Case 1:
Selection formatting when the whole element (start tag, children, end tag) is selected.
![Alt Text](https://raw.githubusercontent.com/xorye/gifs/master/3.gif)
The code looks at the parent element's indentation level, and formats accordingly.

Case 2:
Selection formatting when the start tag (with or without children) is selected.
![Alt Text](https://raw.githubusercontent.com/xorye/gifs/master/4.gif)

Case 3:
Selection formatting when children are selected.
![Alt Text](https://raw.githubusercontent.com/xorye/gifs/master/5.gif)

Case 4:
Selection formatting when the end tag and children are selected
![Alt Text](https://raw.githubusercontent.com/xorye/gifs/master/6.gif)
How this works is that when the code realizes that `</properties>` does not have a start tag within the selected range, it looks for the start tag `this.fullDomDocument`. If found, the indentation of 
`</properties>` will be set to match the indentation of its start tag.
This is achieved here:
https://github.com/xorye/lsp4xml/blob/ac6a02989bbc471e6ad2aa0fc7dfba3aac3039db/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLFormatter.java#L224-L228

Case 5:
This case is the same as Case 4 except, a sibling of `properties` is also selected after `properties`'s ending tag.
![Alt Text](https://raw.githubusercontent.com/xorye/gifs/master/7.gif)
The formatter ensures that the indentation level for `</url>` matches the indentation level for `</properties>`. This is achieved here: https://github.com/xorye/lsp4xml/blob/ac6a02989bbc471e6ad2aa0fc7dfba3aac3039db/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLFormatter.java#L228

To explain why the indentation level (`this.indentLevel`) is now an instance variable rather than a parameter (as it was before this PR), is because in this fix, the indentation level should be able to decrease in special situations like this case (Case 5). 

For example:
![image](https://user-images.githubusercontent.com/20326645/59130839-93133d00-893e-11e9-805e-29b62a352ffd.png)
When range formatting is initiated with the above range, `format()` is called with an initial indentation level of 2, because for line 3 to be properly formatted, it would need to be indented only twice. Since the initial indentation level is 2,
the `format()` method will also indent its sibling on line 4, twice. Upon reaching line 5, this line of code:
https://github.com/xorye/lsp4xml/blob/ac6a02989bbc471e6ad2aa0fc7dfba3aac3039db/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLFormatter.java#L228
correctly decreases the indentation level to 1, since everything on lines
2 and 3 are children of `properties`. Since `url` in line 6 is a sibling of `properties`, it should have an indentation level that matches `properties`. Since `this.indentLevel` is an instance variable, 
it is assured that when the indentation level was set to 1, it will still be 1 by the time `format()` formats `url`. If the indentation level was a method parameter instead, when the indentation level is decreased to 
1, the indentation level would remain at 2 by the time `format()` reaches `url`

What does not work:
Case 5, but if `properties` has an indentation level of 0.
![Alt Text](https://raw.githubusercontent.com/xorye/gifs/master/9.gif)
The `format()` method will not add a newline if the indentation level is 0.
https://github.com/xorye/lsp4xml/blob/ac6a02989bbc471e6ad2aa0fc7dfba3aac3039db/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLFormatter.java#L218-L221

There may definitely still be many other errors.

Another idea that may be less prone to errors:
Since the nodes in `this.rangeDomDocument` are a subset of nodes in `this.fullDomDocument`, get rid of `this.rangeDomDocument` and have only `this.fullDomDocument`, but keep track of the selected range. 
For each node in the selected range, format the nodes' indentations by determining the # of ancestors for that node (ie, if a node has 2 ancestors, have 2 indents). The problem with this way, is that we
do not get to easily reuse `format()`, which contains a lot of formatting logic already. 