### PR TITLE
Preference 'xml.symbols.exclude' for an array of patterns to exclude symbols for file(s)

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/settings/XMLFileAssociation.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/settings/XMLFileAssociation.java
@@ -10,34 +10,20 @@
  */
 package org.eclipse.lsp4xml.extensions.contentmodel.settings;
 
-import java.net.URI;
-import java.nio.file.FileSystems;
-import java.nio.file.PathMatcher;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.eclipse.lsp4xml.settings.PathPatternMatcher;
 import org.eclipse.lsp4xml.uriresolver.IExternalSchemaLocationProvider;
 
 /**
  * XML file association between a XML file pattern (glob) and an XML Schema file
  * (systemId).
  **/
-public class XMLFileAssociation {
+public class XMLFileAssociation extends PathPatternMatcher {
 
-	private transient PathMatcher pathMatcher;
 	private transient Map<String, String> externalSchemaLocation;
-	private String pattern;
 	private String systemId;
-
-	public String getPattern() {
-		return pattern;
-	}
-
-	public void setPattern(String pattern) {
-		this.pattern = pattern;
-		this.pathMatcher = null;
-	}
 
 	public String getSystemId() {
 		return systemId;
@@ -46,35 +32,6 @@ public class XMLFileAssociation {
 	public void setSystemId(String systemId) {
 		this.systemId = systemId;
 		this.externalSchemaLocation = null;
-	}
-
-	public boolean matches(String uri) {
-		try {
-			return matches(new URI(uri));
-		} catch (Exception e) {
-			return false;
-		}
-	}
-
-	public boolean matches(URI uri) {
-		if (pattern.length() < 1) {
-			return false;
-		}
-		if (pathMatcher == null) {
-			char c = pattern.charAt(0);
-			String glob = pattern;
-			if (c != '*' && c != '?' && c != '/') {
-				// in case of pattern like this pattern="myFile*.xml", we must add '**/' before
-				glob = "**/" + glob;
-			}
-			pathMatcher = FileSystems.getDefault().getPathMatcher("glob:" + glob);
-		}
-		try {
-			return pathMatcher.matches(Paths.get(uri));
-		} catch (Exception e) {
-			// e.printStackTrace();
-		}
-		return false;
 	}
 
 	public Map<String, String> getExternalSchemaLocation() {
@@ -89,7 +46,7 @@ public class XMLFileAssociation {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result + ((pattern == null) ? 0 : pattern.hashCode());
+		result = prime * result + ((getPattern() == null) ? 0 : getPattern().hashCode());
 		result = prime * result + ((systemId == null) ? 0 : systemId.hashCode());
 		return result;
 	}
@@ -103,10 +60,12 @@ public class XMLFileAssociation {
 		if (getClass() != obj.getClass())
 			return false;
 		XMLFileAssociation other = (XMLFileAssociation) obj;
-		if (pattern == null) {
-			if (other.pattern != null)
+		String thisPattern = getPattern();
+		String otherPattern = other.getPattern();
+		if (thisPattern == null) {
+			if (otherPattern != null)
 				return false;
-		} else if (!pattern.equals(other.pattern))
+		} else if (!thisPattern.equals(otherPattern))
 			return false;
 		if (systemId == null) {
 			if (other.systemId != null)

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/PathPatternMatcher.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/PathPatternMatcher.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.settings;
+
+import java.net.URI;
+import java.nio.file.FileSystems;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+public class PathPatternMatcher {
+
+	private transient PathMatcher pathMatcher;
+	private String pattern;
+
+	public String getPattern() {
+		return pattern;
+	}
+
+	public void setPattern(String pattern) {
+		this.pattern = pattern;
+		this.pathMatcher = null;
+	}
+
+	public PathMatcher getPathMatcher() {
+		return pathMatcher;
+	}
+
+	public void setPathMatcher(PathMatcher pathMatcher) {
+		this.pathMatcher = pathMatcher;
+	}
+
+	public boolean matches(String uri) {
+		try {
+			return matches(new URI(uri));
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	public boolean matches(URI uri) {
+		if (pattern.length() < 1) {
+			return false;
+		}
+		if (pathMatcher == null) {
+			char c = pattern.charAt(0);
+			String glob = pattern;
+			if (c != '*' && c != '?' && c != '/') {
+				// in case of pattern like this pattern="myFile*.xml", we must add '**/' before
+				glob = "**/" + glob;
+			}
+			pathMatcher = FileSystems.getDefault().getPathMatcher("glob:" + glob);
+		}
+		try {
+			return pathMatcher.matches(Paths.get(uri));
+		} catch (Exception e) {
+			// e.printStackTrace();
+		}
+		return false;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if(this == obj) {
+			return true;
+		}
+
+		if(obj instanceof PathPatternMatcher) {
+			PathPatternMatcher other = (PathPatternMatcher) obj;
+			if(!Objects.equals(pathMatcher, other.getPathMatcher())) {
+				return false;
+			}
+			if(!Objects.equals(pattern, other.getPattern())) {
+				return false;
+			}
+			return true;
+		}
+		return false;
+	}
+
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/XMLExcludedSymbolFile.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/XMLExcludedSymbolFile.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.lsp4xml.settings;
+
+import java.util.Objects;
+
+/**
+ * XMLExcludedSymbolFiles
+ */
+public class XMLExcludedSymbolFile extends PathPatternMatcher{
+
+	public XMLExcludedSymbolFile(String pattern) {
+		setPattern(pattern);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if(this == obj) {
+			return true;
+		}
+
+		if(!(obj instanceof XMLExcludedSymbolFile)) {
+			return false;
+		}
+
+		XMLExcludedSymbolFile comparison = (XMLExcludedSymbolFile) obj;
+		if(!Objects.equals(comparison.getPattern(), getPattern())) {
+			return false;
+		}
+
+		if(!Objects.equals(comparison.getPathMatcher(), getPathMatcher())) {
+			return false;
+		}
+		return true;
+	}
+
+	
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/XMLSymbolSettings.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/XMLSymbolSettings.java
@@ -15,7 +15,15 @@ package org.eclipse.lsp4xml.settings;
  */
 public class XMLSymbolSettings {
 
+	private transient XMLExcludedSymbolFile[] excludedFiles;
+
 	private boolean enabled = true;
+
+	private String[] excluded;
+
+	public XMLExcludedSymbolFile[] getExcludedFiles() {
+		return excludedFiles;
+	}
 
 	public boolean isEnabled() {
 		return enabled;
@@ -24,4 +32,43 @@ public class XMLSymbolSettings {
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
 	}
+
+	public String[] getExcluded() {
+		return excluded;
+	}
+
+	/**
+	 * Will use the excluded pattern strings to create a list of
+	 * {@link XMLExcludedSymbolFile} objects within this object.
+	 * @param excluded
+	 */
+	public void setExcluded(String[] excluded) {
+		XMLExcludedSymbolFile[] exclusions = new XMLExcludedSymbolFile[excluded.length];
+
+		for(int i = 0; i < excluded.length; i++) {
+			exclusions[i] = new XMLExcludedSymbolFile(excluded[i]);
+		}
+
+		excludedFiles = exclusions;
+	}
+
+	/**
+	 * Given a file URI, this will check if it matches any of the given
+	 * file patterns.
+	 * 
+	 * A uri is 'excluded' if it matches any of the given patterns.
+	 * 
+	 * **Important:** Set the excluded file patterns before calling this using 'setExcluded()'.
+	 * @param uri
+	 * @return
+	 */
+	public boolean isExcluded(String uri) {
+		for (XMLExcludedSymbolFile excludedFile : excludedFiles) {
+			if(excludedFile.matches(uri)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 }

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/settings/XMLSymbolSettingsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/settings/XMLSymbolSettingsTest.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.lsp4xml.settings;
+
+import static org.eclipse.lsp4xml.utils.OSUtils.isWindows;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * XMLSymbolsSettingsTest
+ */
+public class XMLSymbolSettingsTest {
+
+	@Test
+	public void isExcludedTest() {
+		XMLSymbolSettings symbolSettings = new XMLSymbolSettings();
+		symbolSettings.setExcluded(new String[] {"**/*.xsd", "**/*.xml"});
+		assertTrue(symbolSettings.isExcluded("file:///nikolas/komonen/test.xml"));
+		assertTrue(symbolSettings.isExcluded("file:///C:/Users/Nikolas/test.xsd"));
+		assertFalse(symbolSettings.isExcluded("file:///nikolas/komonen/test.java"));
+	}
+}


### PR DESCRIPTION
No tests yet


The structure of this PR.

So for the patterns it will take in an array of patterns as strings.
The server will convert those patterns to XMLExcludedSymbolFiles classes.

Each TextDocument has a doSymbols Boolean.
When symbols is requested on it it will check if that Boolean has been set yet, or else it will compute a pattern match.

Let me know if this works or could be improved.