### PR TITLE
Element/Attribute names must be case sensitive (see #433)

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/DOMElement.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/DOMElement.java
@@ -16,6 +16,7 @@ import static org.eclipse.lsp4xml.dom.DOMAttr.XMLNS_NO_DEFAULT_ATTR;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 
 import org.eclipse.lsp4xml.utils.StringUtils;
 import org.w3c.dom.DOMException;
@@ -148,7 +149,6 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 		if (hasAttributes()) {
 			Collection<String> prefixes = new ArrayList<>();
 			for (DOMAttr attr : getAttributeNodes()) {
-				String attributeName = attr.getName();
 				if (attr.isNoDefaultXmlns()) {
 					prefixes.add(attr.extractPrefixFromXmlns());
 				}
@@ -259,9 +259,16 @@ public class DOMElement extends DOMNode implements org.w3c.dom.Element {
 	}
 
 
-	public boolean isSameTag(String tagInLowerCase) {
-		return this.tag != null && tagInLowerCase != null && this.tag.length() == tagInLowerCase.length()
-				&& this.tag.toLowerCase().equals(tagInLowerCase);
+	/**
+	 * Returns true if the given tag is the same tag of this element and false
+	 * otherwise.
+	 * 
+	 * @param tag tag element
+	 * @return true if the given tag is the same tag of this element and false
+	 *         otherwise.
+	 */
+	public boolean isSameTag(String tag) {
+		return Objects.equals(this.tag, tag);
 	}
 
 	public boolean isInStartTag(int offset) {

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/DOMParser.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/DOMParser.java
@@ -158,7 +158,7 @@ public class DOMParser {
 				/**
 				eg: <a><b><c></d> will set a,b,c end position to the start of |</d>
 				*/
-				while (!(curr.isElement() && ((DOMElement) curr).isSameTag(closeTag.toLowerCase())) && curr.parent != null) {
+				while (!(curr.isElement() && ((DOMElement) curr).isSameTag(closeTag)) && curr.parent != null) {
 					curr.end = endTagOpenOffset;
 					curr = curr.parent;
 				}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/parser/XMLScanner.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/parser/XMLScanner.java
@@ -59,15 +59,15 @@ public class XMLScanner implements Scanner {
 	}
 
 	String nextElementName() {
-		return stream.advanceIfRegExp(ELEMENT_NAME_REGEX).toLowerCase();
+		return stream.advanceIfRegExp(ELEMENT_NAME_REGEX);
 	}
 
 	String nextAttributeName() {
-		return stream.advanceIfRegExp(ATTRIBUTE_NAME_REGEX).toLowerCase();
+		return stream.advanceIfRegExp(ATTRIBUTE_NAME_REGEX);
 	}
 
 	String doctypeName() {
-		return stream.advanceIfRegExp(ELEMENT_NAME_REGEX).toLowerCase();
+		return stream.advanceIfRegExp(ELEMENT_NAME_REGEX);
 	}
 
 	/**

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLHighlightingTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLHighlightingTest.java
@@ -73,9 +73,9 @@ public class XMLHighlightingTest {
 	}
 
 	@Test
-	public void caseInsensivity() throws BadLocationException {
-		assertHighlights("<HTML><diV><Div></dIV></dI|v></html>", new int[] { 7, 24 }, "div");
-		assertHighlights("<HTML><diV|><Div></dIV></dIv></html>", new int[] { 7, 24 }, "div");
+	public void caseSensitive() throws BadLocationException {
+		assertHighlights("<HTML><diV><Div></dIV></dI|v></html>", new int[] { 24 }, "div");
+		assertHighlights("<HTML><diV|><Div></dIV></dIv></html>", new int[] { 7 }, "div");
 	}
 	
 	@Test

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLRenameTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLRenameTest.java
@@ -78,9 +78,9 @@ public class XMLRenameTest {
 	}
 
 	@Test
-	public void caseInsensivity() throws BadLocationException {
-		assertRename("<HTML><diV><Div></dIV></dI|v></html>", "newText", edits("newText", r(0, 7, 10), r(0, 24, 27)));
-		assertRename("<HTML><diV|><Div></dIV></dIv></html>", "newText", edits("newText", r(0, 7, 10), r(0, 24, 27)));
+	public void caseSensitive() throws BadLocationException {
+		assertRename("<HTML><diV><Div></dIV></dI|v></html>", "newText", edits("newText", r(0, 24, 27)));
+		assertRename("<HTML><diV|><Div></dIV></dIv></html>", "newText", edits("newText", r(0, 7, 10)));
 	}
 
 	@Test


### PR DESCRIPTION
This PR fix #433 and avoid using String#toLowerCase() which creates a
lot of instances of String.