### PR TITLE
Fix error range for cos-all-limited.2

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/DOMNode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/DOMNode.java
@@ -15,6 +15,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
+import java.util.Objects;
+
 import org.w3c.dom.DOMException;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
@@ -376,6 +378,26 @@ public abstract class DOMNode implements Node {
 
 	public List<DOMAttr> getAttributeNodes() {
 		return attributeNodes;
+	}
+
+	/**
+	 * Returns a list of children, each having an attribute called name, with a value
+	 * of value
+	 * @param name name of attribute
+	 * @param value value of attribute
+	 * @return  list of children, each having a specified attribute name and value
+	 */
+	public List<DOMNode> getChildrenWithAttributeValue(String name, String value) {
+		List<DOMNode> result = new ArrayList<>();
+		for (DOMNode child: getChildren()) {
+			if (child.hasAttribute(name)) {
+				String attrValue = child.getAttribute(name);
+				if (Objects.equals(attrValue, value)) {
+					result.add(child);
+				}
+			}
+		}
+		return result;
 	}
 
 	/**

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
@@ -11,11 +11,13 @@
 package org.eclipse.lsp4xml.extensions.xsd.participants;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.xerces.xni.XMLLocator;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4xml.dom.DOMDocument;
+import org.eclipse.lsp4xml.dom.DOMNode;
 import org.eclipse.lsp4xml.services.extensions.diagnostics.IXMLErrorCode;
 import org.eclipse.lsp4xml.utils.XMLPositionUtility;
 
@@ -82,7 +84,18 @@ public enum XSDErrorCode implements IXMLErrorCode {
 		int offset = location.getCharacterOffset() - 1;
 		// adjust positions
 		switch (code) {
-		case cos_all_limited_2:
+		case cos_all_limited_2: {
+			String nameValue = (String) arguments[1];
+			DOMNode parent = document.findNodeAt(offset);
+			List<DOMNode> children = parent.getChildrenWithAttributeValue("name", nameValue);
+
+			if (children.isEmpty()) {
+				return XMLPositionUtility.selectStartTag(offset, document);
+			}
+
+			offset = children.get(0).getStart() + 1;
+			return XMLPositionUtility.selectAttributeValueAt("maxOccurs", offset, document);
+		}
 		case s4s_elt_invalid_content_1:
 		case s4s_elt_must_match_1:
 		case s4s_att_must_appear:

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
@@ -27,17 +27,38 @@ public class XSDValidationExtensionsTest {
 
 	@Test
 	public void cos_all_limited_2() throws BadLocationException {
-		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
-				"<xs:schema \r\n" +
-				"	xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n" +
-				"	\r\n" +
-				"	<xs:complexType name=\"testType\">\r\n" +
-				"		<xs:all>\r\n" +
-				"			<xs:element name=\"testEle\" minOccurs=\"2\" maxOccurs=\"unbounded\" type=\"xs:string\"/>\r\n" +
-				"		</xs:all>\r\n" +
-				"	</xs:complexType>\r\n" +
-				"</xs:schema>";;
-		testDiagnosticsFor(xml, d(5, 3, 5, 9, XSDErrorCode.cos_all_limited_2));
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<xs:schema \r\n" + //
+				"	xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n" + //
+				"	\r\n" + //
+				"	<xs:complexType name=\"testType\">\r\n" + //
+				"		<xs:all>\r\n" + //
+				"			<xs:element name=\"testEle1\" minOccurs=\"2\" maxOccurs=\"unbounded\" type=\"xs:string\"/>\r\n" + //
+				"		</xs:all>\r\n" + //
+				"	</xs:complexType>\r\n" + //
+				"</xs:schema>";
+		testDiagnosticsFor(xml, d(6, 55, 6, 66, XSDErrorCode.cos_all_limited_2));
+	}
+
+	@Test
+	public void cos_all_limited_2_multiple() throws BadLocationException {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
+				"<xs:schema \r\n" + //
+				"	xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n" + //
+				"	\r\n" + //
+				"	<xs:complexType name=\"testType\">\r\n" + //
+				"		<xs:all>\r\n" + //
+				"			<xs:element name=\"testEle1\" minOccurs=\"2\" maxOccurs=\"unbounded\" type=\"xs:string\"/>\r\n" + //
+				"			<xs:element name=\"testEle2\" minOccurs=\"2\" maxOccurs=\"unbounded\" type=\"xs:string\"/>\r\n" + //
+				"			<xs:element name=\"test3\" minOccurs=\"2\" maxOccurs=\"unbounded\" type=\"xs:string\"/>\r\n" + //
+				"		</xs:all>\r\n" + //
+				"	</xs:complexType>\r\n" + //
+				"</xs:schema>";
+
+		Diagnostic first = d(6, 55, 6, 66, XSDErrorCode.cos_all_limited_2);
+		Diagnostic second = d(7, 55, 7, 66, XSDErrorCode.cos_all_limited_2);
+		Diagnostic third = d(8, 52, 8, 63, XSDErrorCode.cos_all_limited_2);
+		testDiagnosticsFor(xml, first, second, third);
 	}
 
 	@Test


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20326645/59377598-87e65580-8d20-11e9-8765-28db1b306872.png)

In `XSDErrorCode.java`, the arguments that xerces gives back is "unbounded" and "testEle".

Therefore:
`arguments[0] = "unbounded"`, which is the value for the attribute `maxOccurs`
`arguments[1] = "testEle"`, which is the value for attribute `name`
Because of this, I hardcoded `"maxOccurs"` and `"name"` in my code.

My solution works under the assumption that the `name` attribute exists and the cos-all-limited.2 error only occurs with the `maxOccurs` attribute.

This seems to be the case because `maxOccurs` is mentioned from the error message from xerces, and is not included in the arguments, neither is it provided as a parameter for the error message formatter.

I may be wrong and cos-all-limited.2 may occur with attributes other than "maxOccurs". I could not easily find any documentation on this error.

Lastly, xerces provides the location of the parent node of the element with the "unbounded" value. Given the parent, I found the child node with the correct name and got the range for the "unbounded" value for that child.

Signed-off-by: David Kwon <dakwon@redhat.com>