### PR TITLE
Fix error range for p-props-correct.2.1

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
@@ -30,6 +30,7 @@ import org.eclipse.lsp4xml.utils.XMLPositionUtility;
 public enum XSDErrorCode implements IXMLErrorCode {
 	
 	cos_all_limited_2("cos-all-limited.2"),
+	p_props_correct_2_1("p-props-correct.2.1"),
 	s4s_elt_invalid_content_1("s4s-elt-invalid-content.1"), //
 	s4s_elt_must_match_1("s4s-elt-must-match.1"), //
 	s4s_att_must_appear("s4s-att-must-appear"), //
@@ -96,6 +97,8 @@ public enum XSDErrorCode implements IXMLErrorCode {
 			offset = children.get(0).getStart() + 1;
 			return XMLPositionUtility.selectAttributeValueAt("maxOccurs", offset, document);
 		}
+		case p_props_correct_2_1:
+			return XMLPositionUtility.selectAttributeFromGivenNameAt("minOccurs", offset, document);
 		case s4s_elt_invalid_content_1:
 		case s4s_elt_must_match_1:
 		case s4s_att_must_appear:

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
@@ -62,6 +62,37 @@ public class XSDValidationExtensionsTest {
 	}
 
 	@Test
+	public void p_props_correct_2_1() throws BadLocationException {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n" +
+				"	<xs:complexType name=\"testType\">\r\n" +
+				"		<xs:all>\r\n" +
+				"			<xs:element name=\"testEle\" minOccurs=\"1\" maxOccurs=\"0\" type=\"xs:string\"/>\r\n" +
+				"		</xs:all>\r\n" +
+				"	</xs:complexType>\r\n" +
+				"</xs:schema>";
+		testDiagnosticsFor(xml, d(4, 30, 4, 43, XSDErrorCode.p_props_correct_2_1));
+	}
+
+	@Test
+	public void p_props_correct_2_1_multiple() throws BadLocationException {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n" +
+			"	<xs:complexType name=\"testType\">\r\n" +
+			"		<xs:all>\r\n" +
+			"			<xs:element name=\"testEle\" minOccurs=\"1\" maxOccurs=\"0\" type=\"xs:string\"/>\r\n" +
+			"			<xs:element name=\"test\" minOccurs=\"5\" maxOccurs=\"0\" type=\"xs:string\"/>\r\n" +
+			"		</xs:all>\r\n" +
+			"	</xs:complexType>\r\n" +
+			"</xs:schema>";
+		
+		Diagnostic first = d(4, 30, 4, 43, XSDErrorCode.p_props_correct_2_1);
+		Diagnostic second = d(5, 27, 5, 40, XSDErrorCode.p_props_correct_2_1);
+		testDiagnosticsFor(xml, first, second);
+	}
+
+
+	@Test
 	public void s4s_elt_invalid_content_1() throws BadLocationException {
 		String xml = "<?xml version=\"1.1\"?>\r\n" + //
 				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\r\n" + //


### PR DESCRIPTION
Fixes #436 

![image](https://user-images.githubusercontent.com/20326645/59524339-98720980-8ea1-11e9-9672-50a21b79bc6d.png)


There were three arguments provided by xerces:
`arguments[0] = "element"` (from `<xs:element`)
`arguments[1] = XInt(1)` (value of `minOccurs`)
`arguments[2] = XInt(0)` (value of `maxOccurs`)

The location given by xerces is the location of the element with the error.

Signed-off-by: David Kwon <dakwon@redhat.com>