### PR TITLE
Fix src-element.3 error range

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/XMLSchemaErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/XMLSchemaErrorCode.java
@@ -67,7 +67,8 @@ public enum XMLSchemaErrorCode implements IXMLErrorCode {
 	cvc_minInclusive_valid("cvc-minInclusive-valid"), // https://wiki.xmldation.com/Support/validator/cvc-mininclusive-valid
 	TargetNamespace_2("TargetNamespace.2"), 
 	SchemaLocation("SchemaLocation"),
-	schema_reference_4("schema_reference.4"); //
+	schema_reference_4("schema_reference.4"), //
+	src_element_3("src-element.3");
 
 	private final String code;
 
@@ -128,6 +129,7 @@ public enum XMLSchemaErrorCode implements IXMLErrorCode {
 		case cvc_complex_type_2_4_f:
 		case cvc_elt_1_a:
 		case cvc_complex_type_4:
+		case src_element_3:
 		case TargetNamespace_2:
 			return XMLPositionUtility.selectStartTag(offset, document);
 		case cvc_complex_type_3_2_2: {

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
@@ -38,6 +38,7 @@ public enum XSDErrorCode implements IXMLErrorCode {
 	s4s_att_not_allowed("s4s-att-not-allowed"), //
 	s4s_att_invalid_value("s4s-att-invalid-value"), //
 	s4s_elt_character("s4s-elt-character"), //
+	src_element_3("src-element.3"),
 	src_resolve_4_2("src-resolve.4.2"), //
 	src_resolve("src-resolve"), src_element_2_1("src-element.2.1");
 
@@ -104,6 +105,7 @@ public enum XSDErrorCode implements IXMLErrorCode {
 		case s4s_att_must_appear:
 		case s4s_elt_invalid_content_2:
 		case src_element_2_1:
+		case src_element_3:
 			return XMLPositionUtility.selectStartTag(offset, document);
 		case s4s_att_not_allowed: {
 			String attrName = (String) arguments[1];

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
@@ -393,6 +393,15 @@ public class XMLSchemaDiagnosticsTest {
 					d(4,10,4,17, XMLSchemaErrorCode.cvc_type_3_1_3));
 	}
 
+	@Test
+	public void testSrcElement3() throws Exception {
+		String xml = "<a xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\r\n" + //
+		"	xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/srcElement3.xsd\">\r\n" +
+		"	<b></b>\r\n" +
+		"</a>";
+		testDiagnosticsFor(xml, d(0, 1, 0, 2, XMLSchemaErrorCode.src_element_3));
+	}
+
 	private static void testDiagnosticsFor(String xml, Diagnostic... expected) {
 		XMLAssert.testDiagnosticsFor(xml, "src/test/resources/catalogs/catalog.xml", expected);
 	}

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
@@ -202,6 +202,20 @@ public class XSDValidationExtensionsTest {
 				d(5, 17, 5, 27, XSDErrorCode.src_element_2_1));
 	}
 
+	@Test
+	public void src_element_3() throws BadLocationException {
+		String xml = "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n" +
+			"  <xs:element name=\"a\" type=\"xs:integer\">\r\n" +
+			"    <xs:complexType>\r\n" +
+			"      <xs:sequence>\r\n" +
+			"        <xs:element name=\"b\"></xs:element>\r\n" +
+			"      </xs:sequence>\r\n" +
+			"    </xs:complexType>\r\n" +
+			"  </xs:element>\r\n" +
+			"</xs:schema>";
+		testDiagnosticsFor(xml, d(1, 3, 1, 13, XSDErrorCode.src_element_3));
+	}
+
 	private static void testDiagnosticsFor(String xml, Diagnostic... expected) throws BadLocationException {
 		XMLAssert.testDiagnosticsFor(xml, null, null, "test.xsd", expected);
 	}

--- a/org.eclipse.lsp4xml/src/test/resources/xsd/srcElement3.xsd
+++ b/org.eclipse.lsp4xml/src/test/resources/xsd/srcElement3.xsd
@@ -1,0 +1,9 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="a" type="xs:integer">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="b"></xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
Fixes #420 

Upon looking at how this error is handled in IntelliJ and Eclipse, this is what I found:

IntelliJ
For xsd, there is no error
For xml, there is an error on the `b` tag name

Eclipse
For xsd, the error is on the whole line that contains `<xs:element name="a" type="xs:integer">`
For xml, there is no error.

This fix displays an error for both xsd and xml.

The error ranges look like the following:
xml:
![image](https://user-images.githubusercontent.com/20326645/59384312-e961f080-8d2f-11e9-9d48-36bebe9883ea.png)

xsd:
![image](https://user-images.githubusercontent.com/20326645/59384282-d9e2a780-8d2f-11e9-8d60-b4ef3cf25bc7.png)

Signed-off-by: David Kwon <dakwon@redhat.com>