### PR TITLE
Prevent from NPE when excluded files for symbol is not defined

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/XMLSymbolSettings.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/XMLSymbolSettings.java
@@ -63,6 +63,9 @@ public class XMLSymbolSettings {
 	 * @return
 	 */
 	public boolean isExcluded(String uri) {
+		if (excludedFiles == null) {
+			return false;
+		}
 		for (XMLExcludedSymbolFile excludedFile : excludedFiles) {
 			if(excludedFile.matches(uri)) {
 				return true;


### PR DESCRIPTION
Prevent from NPE when excluded files for symbol is not defined.

@NikolasKomonen please review this important PR because outline cannot display symbol (in Eclipse)