### PR TITLE
Add support for `textDocument/definition` for XML Schema

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/DOMAttr.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/dom/DOMAttr.java
@@ -27,9 +27,9 @@ public class DOMAttr extends DOMNode implements org.w3c.dom.Attr {
 
 	private DOMNode nodeAttrValue;
 
-	private String quotelessValue;//Value without quotes
+	private String quotelessValue;// Value without quotes
 
-	private String originalValue;//Exact value from document
+	private String originalValue;// Exact value from document
 
 	private final DOMNode ownerElement;
 
@@ -104,9 +104,14 @@ public class DOMAttr extends DOMNode implements org.w3c.dom.Attr {
 	}
 
 	@Override
+	public String getNodeValue() throws DOMException {
+		return getValue();
+	}
+
+	@Override
 	public String getLocalName() {
 		int colonIndex = name.indexOf(":");
-		if(colonIndex > 0) {
+		if (colonIndex > 0) {
 			return name.substring(colonIndex + 1);
 		}
 		return name;
@@ -119,6 +124,11 @@ public class DOMAttr extends DOMNode implements org.w3c.dom.Attr {
 	 */
 	public DOMElement getOwnerElement() {
 		return ownerElement.isElement() ? (DOMElement) ownerElement : null;
+	}
+	
+	@Override
+	public DOMDocument getOwnerDocument() {
+		return ownerElement != null ? ownerElement.getOwnerDocument() : null;
 	}
 
 	/*
@@ -186,6 +196,7 @@ public class DOMAttr extends DOMNode implements org.w3c.dom.Attr {
 	 * Get original attribute value from the document.
 	 * 
 	 * This will include quotations (", ').
+	 * 
 	 * @return attribute value with quotations if it had them.
 	 */
 	public String getOriginalValue() {
@@ -200,6 +211,7 @@ public class DOMAttr extends DOMNode implements org.w3c.dom.Attr {
 
 	/**
 	 * Returns a String of 'value' without surrounding quotes if it had them.
+	 * 
 	 * @param value
 	 * @return
 	 */
@@ -219,6 +231,7 @@ public class DOMAttr extends DOMNode implements org.w3c.dom.Attr {
 
 	/**
 	 * Checks if 'value' has matching surrounding quotations.
+	 * 
 	 * @param value
 	 * @return
 	 */
@@ -231,11 +244,12 @@ public class DOMAttr extends DOMNode implements org.w3c.dom.Attr {
 		}
 		char quoteValueStart = value.charAt(0);
 		boolean start = quoteValueStart == '\"' || quoteValueStart == '\'' ? true : false;
-		if(start == false) {
+		if (start == false) {
 			return false;
 		}
 		char quoteValueEnd = value.charAt(value.length() - 1);
-		boolean end = (quoteValueEnd == '\"' || quoteValueEnd == '\'') && quoteValueEnd == quoteValueStart ? true : false;
+		boolean end = (quoteValueEnd == '\"' || quoteValueEnd == '\'') && quoteValueEnd == quoteValueStart ? true
+				: false;
 		return end;
 	}
 
@@ -292,6 +306,7 @@ public class DOMAttr extends DOMNode implements org.w3c.dom.Attr {
 	 * Returns the prefix if the given URI matches this attributes value.
 	 * 
 	 * If the URI doesnt match, null is returned.
+	 * 
 	 * @param uri
 	 * @return
 	 */
@@ -320,12 +335,12 @@ public class DOMAttr extends DOMNode implements org.w3c.dom.Attr {
 	public boolean isNoDefaultXmlns() {
 		return isNoDefaultXmlns(name);
 	}
-	
+
 	public static boolean isNoDefaultXmlns(String attributeName) {
 		return attributeName.startsWith(XMLNS_NO_DEFAULT_ATTR);
 	}
 
-		/*
+	/*
 	 * (non-Javadoc)
 	 * 
 	 * @see org.w3c.dom.Node#getNextSibling()

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/references/participants/XMLReferencesDefinitionParticipant.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/references/participants/XMLReferencesDefinitionParticipant.java
@@ -12,33 +12,29 @@ package org.eclipse.lsp4xml.extensions.references.participants;
 
 import java.util.List;
 
-import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4xml.commons.BadLocationException;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4xml.dom.DOMDocument;
 import org.eclipse.lsp4xml.dom.DOMNode;
 import org.eclipse.lsp4xml.extensions.references.XMLReferencesManager;
-import org.eclipse.lsp4xml.services.extensions.IDefinitionParticipant;
+import org.eclipse.lsp4xml.services.extensions.AbstractDefinitionParticipant;
 import org.eclipse.lsp4xml.utils.XMLPositionUtility;
 
-public class XMLReferencesDefinitionParticipant implements IDefinitionParticipant {
+public class XMLReferencesDefinitionParticipant extends AbstractDefinitionParticipant {
 
 	@Override
-	public void findDefinition(DOMDocument document, Position position, List<Location> locations) {
-		try {
-			int offset = document.offsetAt(position);
-			DOMNode node = document.findNodeAt(offset);
-			if (node != null) {
-				XMLReferencesManager.getInstance().collect(node, n -> {
-					DOMDocument doc = n.getOwnerDocument();
-					Range range = XMLPositionUtility.createRange(n.getStart(), n.getEnd(), doc);
-					locations.add(new Location(doc.getDocumentURI(), range));
-				});
-			}
-		} catch (BadLocationException e) {
+	protected boolean match(DOMDocument document) {
+		return true;
+	}
 
-		}
+	@Override
+	protected void findDefinition(DOMNode origin, Position position, int offset, List<LocationLink> locations,
+			CancelChecker cancelChecker) {
+		XMLReferencesManager.getInstance().collect(origin, target -> {
+			LocationLink location = XMLPositionUtility.createLocationLink(origin, target);
+			locations.add(location);
+		});
 	}
 
 }

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/XSDPlugin.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/XSDPlugin.java
@@ -16,8 +16,10 @@ import org.eclipse.lsp4xml.extensions.contentmodel.model.ContentModelManager;
 import org.eclipse.lsp4xml.extensions.contentmodel.model.ContentModelProvider;
 import org.eclipse.lsp4xml.extensions.xsd.contentmodel.CMXSDContentModelProvider;
 import org.eclipse.lsp4xml.extensions.xsd.participants.XSDCompletionParticipant;
+import org.eclipse.lsp4xml.extensions.xsd.participants.XSDDefinitionParticipant;
 import org.eclipse.lsp4xml.extensions.xsd.participants.diagnostics.XSDDiagnosticsParticipant;
 import org.eclipse.lsp4xml.services.extensions.ICompletionParticipant;
+import org.eclipse.lsp4xml.services.extensions.IDefinitionParticipant;
 import org.eclipse.lsp4xml.services.extensions.IXMLExtension;
 import org.eclipse.lsp4xml.services.extensions.XMLExtensionsRegistry;
 import org.eclipse.lsp4xml.services.extensions.diagnostics.IDiagnosticsParticipant;
@@ -31,12 +33,15 @@ public class XSDPlugin implements IXMLExtension {
 
 	private final ICompletionParticipant completionParticipant;
 
+	private final IDefinitionParticipant definitionParticipant;
+
 	private final IDiagnosticsParticipant diagnosticsParticipant;
 
 	private XSDURIResolverExtension uiResolver;
 
 	public XSDPlugin() {
 		completionParticipant = new XSDCompletionParticipant();
+		definitionParticipant = new XSDDefinitionParticipant();
 		diagnosticsParticipant = new XSDDiagnosticsParticipant();
 	}
 
@@ -44,7 +49,7 @@ public class XSDPlugin implements IXMLExtension {
 	public void doSave(ISaveContext context) {
 		String documentURI = context.getUri();
 		DOMDocument document = context.getDocument(documentURI);
-		if(DOMUtils.isXSD(document)) {
+		if (DOMUtils.isXSD(document)) {
 			context.collectDocumentToValidate(d -> {
 				DOMDocument xml = context.getDocument(d.getDocumentURI());
 				return xml.usesSchema(context.getUri());
@@ -63,12 +68,15 @@ public class XSDPlugin implements IXMLExtension {
 		modelManager.registerModelProvider(modelProvider);
 		// register completion, diagnostic particpant
 		registry.registerCompletionParticipant(completionParticipant);
+		registry.registerDefinitionParticipant(definitionParticipant);
 		registry.registerDiagnosticsParticipant(diagnosticsParticipant);
 	}
 
 	@Override
 	public void stop(XMLExtensionsRegistry registry) {
 		registry.getResolverExtensionManager().unregisterResolver(uiResolver);
+		registry.unregisterCompletionParticipant(completionParticipant);
+		registry.unregisterDefinitionParticipant(definitionParticipant);
 		registry.unregisterDiagnosticsParticipant(diagnosticsParticipant);
 	}
 }

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDDefinitionParticipant.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDDefinitionParticipant.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.extensions.xsd.participants;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.LocationLink;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.eclipse.lsp4xml.dom.DOMAttr;
+import org.eclipse.lsp4xml.dom.DOMDocument;
+import org.eclipse.lsp4xml.dom.DOMNode;
+import org.eclipse.lsp4xml.extensions.xsd.utils.XSDUtils;
+import org.eclipse.lsp4xml.services.extensions.AbstractDefinitionParticipant;
+import org.eclipse.lsp4xml.utils.DOMUtils;
+import org.eclipse.lsp4xml.utils.XMLPositionUtility;
+
+/**
+ * XSD definition which manages teh following definition:
+ * 
+ * <ul>
+ * <li>xs:element/@type -> xs:complexType/@name</li> *
+ * <li>xs:extension/@base -> xs:complexType/@name</li>
+ * </ul>
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class XSDDefinitionParticipant extends AbstractDefinitionParticipant {
+
+	@Override
+	protected boolean match(DOMDocument document) {
+		return DOMUtils.isXSD(document);
+	}
+
+	@Override
+	protected void findDefinition(DOMNode node, Position position, int offset, List<LocationLink> locations,
+			CancelChecker cancelChecker) {
+		// - xs:element/@type -> xs:complexType/@name
+		// - xs:extension/@base -> xs:complexType/@name
+		DOMAttr attr = node.findAttrAt(offset);
+		if (XSDUtils.isBoundToComplexTypes(attr)) {
+			XSDUtils.collectComplexTypes(attr, true, (targetNamespacePrefix, targetAttr) -> {
+				LocationLink location = XMLPositionUtility.createLocationLink(attr, targetAttr);
+				locations.add(location);
+			});
+		}
+	}
+
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/utils/XSDUtils.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/utils/XSDUtils.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.extensions.xsd.utils;
+
+import java.util.function.BiConsumer;
+
+import org.eclipse.lsp4xml.dom.DOMAttr;
+import org.eclipse.lsp4xml.dom.DOMDocument;
+import org.eclipse.lsp4xml.dom.DOMElement;
+import org.eclipse.lsp4xml.utils.StringUtils;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import com.google.common.base.Objects;
+
+/**
+ * XSD utilities.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class XSDUtils {
+
+	/**
+	 * Returns true if the given attribute is bound to complexType/@name attribute
+	 * and false otherwise.
+	 * 
+	 * @param attr the attribute
+	 * @return true if the given attribute is bound to complexType/@name attribute
+	 *         and false otherwise.
+	 */
+	public static boolean isBoundToComplexTypes(DOMAttr attr) {
+		if (attr == null) {
+			return false;
+		}
+		if ("type".equals(attr.getName()) && "element".equals(attr.getOwnerElement().getLocalName())) {
+			// - xs:element/@type -> xs:complexType/@name
+			return true;
+		}
+		if ("base".equals(attr.getName()) && "extension".equals(attr.getOwnerElement().getLocalName())) {
+			// - xs:extension/@base -> xs:complexType/@name
+			return true;
+		}
+		return false;
+	}
+
+	/**
+	 * Collect complexType/@name attributes declared inside the document of the
+	 * given attribute.
+	 * 
+	 * @param originAttr the origin attribute.
+	 * @param matchAttr  true if the attribute value must match the value of
+	 *                   complexType/@name and false otherwise.
+	 * @param collector  collector to collect complexType/@name attributes.
+	 */
+	public static void collectComplexTypes(DOMAttr originAttr, boolean matchAttr,
+			BiConsumer<String, DOMAttr> collector) {
+		DOMDocument document = originAttr.getOwnerDocument();
+		DOMElement documentElement = document != null ? document.getDocumentElement() : null;
+		if (documentElement == null) {
+			return;
+		}
+		String attrValue = originAttr.getValue();
+		if (matchAttr && StringUtils.isEmpty(attrValue)) {
+			return;
+		}
+
+		// <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+		// xmlns:tns="http://camel.apache.org/schema/spring"
+		// targetNamespace="http://camel.apache.org/schema/spring" version="1.0">
+		String targetNamespace = documentElement.getAttribute("targetNamespace"); // ->
+																					// http://camel.apache.org/schema/spring
+		String targetNamespacePrefix = documentElement.getPrefix(targetNamespace); // -> tns
+
+		String complexTypeName = attrValue;
+		String prefix = null;
+		int index = attrValue.indexOf(":");
+		if (index != -1) {
+			prefix = attrValue.substring(0, index);
+			if (!Objects.equal(prefix, targetNamespacePrefix)) {
+				return;
+			}
+			complexTypeName = attrValue.substring(index + 1, attrValue.length());
+		}
+
+		// Loop for element complexType.
+		NodeList children = documentElement.getChildNodes();
+		for (int i = 0; i < children.getLength(); i++) {
+			Node node = children.item(i);
+			if (node.getNodeType() == Node.ELEMENT_NODE) {
+				Element element = (Element) node;
+				if ("complexType".equals(element.getLocalName())) {
+					// node is a complexType element
+					// get the attribute complexType/@name
+					DOMAttr targetAttr = (DOMAttr) element.getAttributeNode("name");
+					if (!matchAttr || complexTypeName.equals(targetAttr.getValue())) {
+						collector.accept(targetNamespacePrefix, targetAttr);
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLDefinition.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLDefinition.java
@@ -13,8 +13,9 @@ package org.eclipse.lsp4xml.services;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4xml.dom.DOMDocument;
 import org.eclipse.lsp4xml.services.extensions.IDefinitionParticipant;
 import org.eclipse.lsp4xml.services.extensions.XMLExtensionsRegistry;
@@ -31,10 +32,10 @@ class XMLDefinition {
 		this.extensionsRegistry = extensionsRegistry;
 	}
 
-	public List<? extends Location> findDefinition(DOMDocument document, Position position) {
-		List<Location> locations = new ArrayList<>();
+	public List<? extends LocationLink> findDefinition(DOMDocument document, Position position, CancelChecker cancelChecker) {
+		List<LocationLink> locations = new ArrayList<>();
 		for (IDefinitionParticipant participant : extensionsRegistry.getDefinitionParticipants()) {
-			participant.findDefinition(document, position, locations);
+			participant.findDefinition(document, position, locations, cancelChecker);
 		}
 		return locations;
 	}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLLanguageService.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLLanguageService.java
@@ -28,6 +28,7 @@ import org.eclipse.lsp4j.FoldingRange;
 import org.eclipse.lsp4j.FoldingRangeCapabilities;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.Range;
@@ -38,7 +39,6 @@ import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4xml.commons.BadLocationException;
 import org.eclipse.lsp4xml.commons.TextDocument;
-import org.eclipse.lsp4xml.commons.TextDocumentVersionChecker;
 import org.eclipse.lsp4xml.customservice.AutoCloseTagResponse;
 import org.eclipse.lsp4xml.dom.DOMDocument;
 import org.eclipse.lsp4xml.dom.DOMElement;
@@ -204,8 +204,8 @@ public class XMLLanguageService extends XMLExtensionsRegistry {
 		return documentLink.findDocumentLinks(document);
 	}
 
-	public List<? extends Location> findDefinition(DOMDocument xmlDocument, Position position) {
-		return definition.findDefinition(xmlDocument, position);
+	public List<? extends LocationLink> findDefinition(DOMDocument xmlDocument, Position position, CancelChecker cancelChecker) {
+		return definition.findDefinition(xmlDocument, position, cancelChecker);
 	}
 
 	public List<? extends Location> findReferences(DOMDocument xmlDocument, Position position,

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/AbstractDefinitionParticipant.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/AbstractDefinitionParticipant.java
@@ -1,0 +1,36 @@
+package org.eclipse.lsp4xml.services.extensions;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.LocationLink;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.eclipse.lsp4xml.commons.BadLocationException;
+import org.eclipse.lsp4xml.dom.DOMDocument;
+import org.eclipse.lsp4xml.dom.DOMNode;
+
+public abstract class AbstractDefinitionParticipant implements IDefinitionParticipant {
+
+	@Override
+	public void findDefinition(DOMDocument document, Position position, List<LocationLink> locations,
+			CancelChecker cancelChecker) {
+		if (!match(document)) {
+			return;
+		}
+		try {
+			int offset = document.offsetAt(position);
+			DOMNode node = document.findNodeAt(offset);
+			if (node != null) {
+				findDefinition(node, position, offset, locations, cancelChecker);
+			}
+		} catch (BadLocationException e) {
+
+		}
+	}
+
+	protected abstract boolean match(DOMDocument document);
+
+	protected abstract void findDefinition(DOMNode node, Position position, int offset, List<LocationLink> locations,
+			CancelChecker cancelChecker);
+
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/IDefinitionParticipant.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/IDefinitionParticipant.java
@@ -12,8 +12,9 @@ package org.eclipse.lsp4xml.services.extensions;
 
 import java.util.List;
 
-import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4xml.dom.DOMDocument;
 
 /**
@@ -26,9 +27,11 @@ public interface IDefinitionParticipant {
 	 * Find definition.
 	 * 
 	 * @param document
-	 * @param position 
+	 * @param position
 	 * @param locations
+	 * @param cancelChecker
 	 */
-	void findDefinition(DOMDocument document, Position position, List<Location> locations);
+	void findDefinition(DOMDocument document, Position position, List<LocationLink> locations,
+			CancelChecker cancelChecker);
 
 }

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDDefinitionExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDDefinitionExtensionsTest.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.extensions.xsd;
+
+import static org.eclipse.lsp4xml.XMLAssert.l;
+import static org.eclipse.lsp4xml.XMLAssert.r;
+
+import org.eclipse.lsp4j.LocationLink;
+import org.eclipse.lsp4xml.XMLAssert;
+import org.eclipse.lsp4xml.commons.BadLocationException;
+import org.junit.Test;
+
+/**
+ * XSD definition tests.
+ *
+ */
+public class XSDDefinitionExtensionsTest {
+
+	@Test
+	public void elementTypeDefinition() throws BadLocationException {
+		// completion on |
+		String xml = "<?xml version=\"1.1\" ?>\r\n" + //
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\" attributeFormDefault=\"unqualified\">\r\n"
+				+ //
+				"	\r\n" + //
+				"	<xs:element name=\"employee\" type=\"|fullpersoninfo\" />\r\n" + // here the definition is declared
+																						// in complexType/@name =
+																						// 'fullpersoninfo'
+				"	\r\n" + //
+				"	<xs:complexType name=\"fullpersoninfo\">	\r\n" + //
+				"	</xs:complexType>\r\n" + //
+				"	\r\n" + //
+				"</xs:schema>";
+		testDefinitionFor(xml, l("test.xsd", r(3, 29, 3, 50), r(5, 17, 5, 38)));
+	}
+
+	@Test
+	public void extensionBaseDefinition() throws BadLocationException {
+		// completion on |
+		String xml = "<?xml version=\"1.1\" ?>\r\n" + //
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\" attributeFormDefault=\"unqualified\">\r\n"
+				+ //
+				"	\r\n" + //
+				"	<xs:complexType name=\"personinfo\">\r\n" + //
+				"		\r\n" + //
+				"	</xs:complexType>\r\n" + //
+				"	\r\n" + //
+				"	<xs:complexType name=\"fullpersoninfo\">\r\n" + //
+				"		<xs:complexContent>\r\n" + //
+				"			<xs:extension base=\"|personinfo\">\r\n" + // // here the definition is declared in
+																		// complexType/@name ='personinfo'
+				"		\r\n" + //
+				"			</xs:extension>\r\n" + //
+				"		</xs:complexContent>\r\n" + //
+				"	</xs:complexType>\r\n" + //
+				"	\r\n" + //
+				"</xs:schema>";
+		testDefinitionFor(xml, l("test.xsd", r(9, 17, 9, 34), r(3, 17, 3, 34)));
+	}
+
+	@Test
+	public void targetDefinition() throws BadLocationException {
+		// completion on |
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n"
+				+ "<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:tns=\"http://camel.apache.org/schema/spring\" elementFormDefault=\"qualified\" targetNamespace=\"http://camel.apache.org/schema/spring\" version=\"1.0\">\r\n"
+				+ //
+				"	\r\n" + //
+				"	<xs:element name=\"aggregate\" type=\"|tns:aggregateDefinition\">\r\n" + // here the definition is
+																								// declared in
+																								// complexType/@name
+																								// ='aggregateDefinition'
+				"	</xs:element>\r\n" + //
+				"	\r\n" + //
+				"	<xs:complexType name=\"aggregateDefinition\">\r\n" + //
+				"	</xs:complexType>\r\n" + //
+				"	\r\n" + //
+				"</xs:schema>";
+		testDefinitionFor(xml, l("test.xsd", r(3, 30, 3, 60), r(6, 17, 6, 43)));
+	}
+
+	private static void testDefinitionFor(String xml, LocationLink... expectedItems) throws BadLocationException {
+		XMLAssert.testDefinitionFor(xml, "test.xsd", expectedItems);
+	}
+}


### PR DESCRIPTION
Fix #148

This PR manage the following definition only in the XML Schema (external
definition is not managed):

 - xs:element/@type -> xs:complexType/@name
 - xs:extension/@base -> xs:complexType/@name

Signed-off-by: azerr <azerr@redhat.com>