### PR TITLE
Fix error range for duplicate attribute

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
@@ -107,9 +107,20 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 		}
 		case EncodingDeclRequired:
 		case EqRequiredInXMLDecl:
-		case AttributeNotUnique:
-		case AttributeNSNotUnique:
 			return XMLPositionUtility.selectAttributeNameAt(offset, document);
+		case AttributeNSNotUnique: {
+			String attrName = (String) arguments[1];
+			Range xmlns = XMLPositionUtility.selectAttributeNameFromGivenNameAt("xmlns:" + attrName, offset, document);
+			if (xmlns != null) {
+				return xmlns;
+			}
+			return XMLPositionUtility.selectAttributeNameFromGivenNameAt(attrName, offset, document);
+		}
+		case AttributeNotUnique: {
+			String attrName = (String) arguments[1];
+			return XMLPositionUtility.selectAttributeNameFromGivenNameAt(attrName, offset, document);
+		}
+			
 		case LessthanInAttValue: {
 			String attrName = (String) arguments[1];
 			return XMLPositionUtility.selectAttributeValueAt(attrName, offset, document);

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
@@ -38,7 +38,13 @@ public class XMLSyntaxDiagnosticsTest {
 	@Test
 	public void testAttributeNotUnique() throws Exception {
 		String xml = "<InstdAmt Ccy=\"JPY\" Ccy=\"JPY\" >10000000</InstdAmt>";
-		testDiagnosticsFor(xml, d(0, 20, 0, 23, XMLSyntaxErrorCode.AttributeNotUnique));
+		testDiagnosticsFor(xml, d(0, 10, 0, 13, XMLSyntaxErrorCode.AttributeNotUnique));
+	}
+
+	@Test
+	public void testAttributeNotUnique2() throws Exception {
+		String xml = "<a attr=\"\" attr=\"\" attr2=\"\" />";
+		testDiagnosticsFor(xml, d(0, 3, 0, 7, XMLSyntaxErrorCode.AttributeNotUnique));
 	}
 
 	/**
@@ -52,7 +58,16 @@ public class XMLSyntaxDiagnosticsTest {
 		String xml = "<Document xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns=\"urn:iso:std:iso:20022:tech:xsd:pain.001.001.03\"\r\n"
 				+ "\r\n" + //
 				"xmlns=\"urn:iso:std:iso:20022:tech:xsd:pain.001.001.03\"> ";
-		testDiagnosticsFor(xml, d(2, 0, 2, 5, XMLSyntaxErrorCode.AttributeNSNotUnique));
+		testDiagnosticsFor(xml, d(0, 64, 0, 69, XMLSyntaxErrorCode.AttributeNSNotUnique));
+	}
+
+	@Test
+	public void testAttributeNSNotUnique2() throws Exception {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" \r\n" +
+				"	xmlns:tns=\"http://camel.apache.org/schema/spring\"\r\n" +
+				"	xmlns:tns=\"http://camel.apache.org/schema/spring\" version=\"1.0\">";
+		testDiagnosticsFor(xml, d(2, 1, 2, 10, XMLSyntaxErrorCode.AttributeNSNotUnique));
 	}
 
 	/**


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20326645/59858505-196d4d00-9349-11e9-9165-d0736c75d722.png)

The error range for both `AttributeNSNotUnique` and `AttributeNotUnique` is now on the first occurrence of the duplicate attribute. If needed, it could be on the last occurrence of the attribute, but we would need a method like `DOMNode.getAttributeNode(String prefix, String suffix)`, except it iterates through the list of attributes, backwards.

For the above screenshot, the arguments were:
```
arguments[0] = "xs:schema"
arguments[1] = "tns"
arguments[2] = "http://www.w3.org/2000/xmlns"
```
Signed-off-by: David Kwon <dakwon@redhat.com>