### PR TITLE
Fix bug with completion on XML Schema elements

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLTextDocumentService.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLTextDocumentService.java
@@ -435,11 +435,7 @@ public class XMLTextDocumentService implements TextDocumentService {
 	 * @return the text document from the given uri.
 	 */
 	public ModelTextDocument<DOMDocument> getDocument(String uri) {
-		ModelTextDocument<DOMDocument> document = documents.get(uri);
-		if (document == null) {
-			throw new CancellationException("Cannot find a text document for the uri='" + uri + "'.");
-		}
-		return document;
+		return documents.get(uri);
 	}
 
 	/**


### PR DESCRIPTION
Completion on XML Schema like xs:annotation, inside a xsd file is broken. The getDocument method is called in the services (competion, hover, etc ) wher echeck of NPE should be done but it is called too in XMLCatalogURIResolverExtension, and other extension where getDocument should continue to return PR (and not throw a CancellableException). 

This PR is a simple fix to resolve problem with completion on XML Schema.