### PR TITLE
Fix error range for src-ct.1

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
@@ -38,6 +38,7 @@ public enum XSDErrorCode implements IXMLErrorCode {
 	s4s_att_not_allowed("s4s-att-not-allowed"), //
 	s4s_att_invalid_value("s4s-att-invalid-value"), //
 	s4s_elt_character("s4s-elt-character"), //
+	src_ct_1("src-ct.1"),
 	src_element_3("src-element.3"),
 	src_resolve_4_2("src-resolve.4.2"), //
 	src_resolve("src-resolve"), src_element_2_1("src-element.2.1");
@@ -117,6 +118,8 @@ public enum XSDErrorCode implements IXMLErrorCode {
 		}
 		case s4s_elt_character:
 			return XMLPositionUtility.selectContent(offset, document);
+		case src_ct_1: 
+			return XMLPositionUtility.selectAttributeValueAt("base", offset, document);
 		case src_resolve_4_2: {
 			String attrValue = (String) arguments[2];
 			return XMLPositionUtility.selectAttributeValueByGivenValueAt(attrValue, offset, document);

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
@@ -145,6 +145,20 @@ public class XSDValidationExtensionsTest {
 	}
 
 	@Test
+	public void src_ct_1() throws BadLocationException {
+		String xml = "<?xml version=\"1.1\" ?>\r\n" +
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\" attributeFormDefault=\"unqualified\">\r\n" +
+				"	<xs:complexType name=\"fullpersoninfo\">\r\n" +
+				"		<xs:complexContent>\r\n" +
+				"			<xs:extension base=\"xs:string\">\r\n" +
+				"			</xs:extension>\r\n" +
+				"		</xs:complexContent>\r\n" +
+				"	</xs:complexType>\r\n" +
+				"</xs:schema>";
+		testDiagnosticsFor(xml, d(4, 22, 4, 33, XSDErrorCode.src_ct_1));
+	}
+
+	@Test
 	public void src_resolve() throws BadLocationException {
 		String xml = "<?xml version=\"1.1\"?>\r\n" + //
 				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\r\n" + //


### PR DESCRIPTION
Fixes #453 

![image](https://user-images.githubusercontent.com/20326645/59928539-f99f5d00-940c-11e9-8309-4089635107ea.png)

The arguments provided by xerces were:
```
arguments[0] = "fullpersoninfo"
arguments[1] = "string"
```

The "base" string was hard coded in my solution because this error happens when xerces checks the base type.

Signed-off-by: David Kwon <dakwon@redhat.com>