### PR TITLE
Fix error range for ct-props-correct.3

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
@@ -30,6 +30,7 @@ import org.eclipse.lsp4xml.utils.XMLPositionUtility;
 public enum XSDErrorCode implements IXMLErrorCode {
 	
 	cos_all_limited_2("cos-all-limited.2"),
+	ct_props_correct_3("ct-props-correct.3"),
 	p_props_correct_2_1("p-props-correct.2.1"),
 	s4s_elt_invalid_content_1("s4s-elt-invalid-content.1"), //
 	s4s_elt_must_match_1("s4s-elt-must-match.1"), //
@@ -98,6 +99,11 @@ public enum XSDErrorCode implements IXMLErrorCode {
 
 			offset = children.get(0).getStart() + 1;
 			return XMLPositionUtility.selectAttributeValueAt("maxOccurs", offset, document);
+		}
+		case ct_props_correct_3: {
+			String argument = (String) arguments[0];
+			String attrName = argument.substring(argument.indexOf(":") + 1);
+			return XMLPositionUtility.selectAttributeValueFromGivenValue(attrName, offset, document);
 		}
 		case p_props_correct_2_1:
 			return XMLPositionUtility.selectAttributeFromGivenNameAt("minOccurs", offset, document);

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
@@ -62,6 +62,20 @@ public class XSDValidationExtensionsTest {
 	}
 
 	@Test
+	public void ct_props_correct_3() throws BadLocationException {
+		String xml = "<?xml version=\"1.1\" ?>\r\n" +
+			"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\" attributeFormDefault=\"unqualified\">\r\n" +
+			"	<xs:complexType name=\"fullpersoninfo\">\r\n" +
+			"		<xs:complexContent>\r\n" +
+			"			<xs:extension base=\"fullpersoninfo\">\r\n" +
+			"			</xs:extension>\r\n" +
+			"		</xs:complexContent>\r\n" +
+			"	</xs:complexType>\r\n" +
+			"</xs:schema>";
+		testDiagnosticsFor(xml, d(4, 22, 4, 38, XSDErrorCode.ct_props_correct_3));
+	}
+
+	@Test
 	public void p_props_correct_2_1() throws BadLocationException {
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
 				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n" +


### PR DESCRIPTION
Fixes #455 

![image](https://user-images.githubusercontent.com/20326645/60024420-bf7cc800-9665-11e9-8e7f-1e060234516b.png)


The only argument provided by xerces was:
```
arguments[0] = ":fullpersoninfo"
```

Upon looking at the source code for xerces, https://github.com/apache/xerces2-j/blob/cf0c517a41b31b0242b96ab1af9627a3ab07fcd2/src/org/apache/xerces/impl/xs/traversers/XSDHandler.java#L1773
the value seems to be separated with a ":" every time.

This was my reasoning for `indexOf(":")` at:
https://github.com/xorye/lsp4xml/blob/d41543428b5c6825236e6b1559f1f0f19752388c/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java#L105

Signed-off-by: David Kwon <dakwon@redhat.com>