### PR TITLE
Fix error range for s4s-elt-must-match.2

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
@@ -34,6 +34,7 @@ public enum XSDErrorCode implements IXMLErrorCode {
 	p_props_correct_2_1("p-props-correct.2.1"),
 	s4s_elt_invalid_content_1("s4s-elt-invalid-content.1"), //
 	s4s_elt_must_match_1("s4s-elt-must-match.1"), //
+	s4s_elt_must_match_2("s4s-elt-must-match.2"),
 	s4s_att_must_appear("s4s-att-must-appear"), //
 	s4s_elt_invalid_content_2("s4s-elt-invalid-content.2"), //
 	s4s_att_not_allowed("s4s-att-not-allowed"), //
@@ -109,6 +110,7 @@ public enum XSDErrorCode implements IXMLErrorCode {
 			return XMLPositionUtility.selectAttributeFromGivenNameAt("minOccurs", offset, document);
 		case s4s_elt_invalid_content_1:
 		case s4s_elt_must_match_1:
+		case s4s_elt_must_match_2:
 		case s4s_att_must_appear:
 		case s4s_elt_invalid_content_2:
 		case src_element_2_1:

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
@@ -127,6 +127,15 @@ public class XSDValidationExtensionsTest {
 	}
 
 	@Test
+	public void s4s_elt_must_match_2() throws BadLocationException {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" version=\"1.0\">\r\n" +
+				"	<xs:simpleType name=\"X\"></xs:simpleType>\r\n" +
+				"</xs:schema>";
+		testDiagnosticsFor(xml, d(2, 2, 2, 15, XSDErrorCode.s4s_elt_must_match_2));
+	}
+
+	@Test
 	public void s4s_att_must_appear() throws BadLocationException {
 		String xml = "<?xml version=\"1.1\"?>\r\n" + //
 				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\r\n" + //


### PR DESCRIPTION
Fixes #458 

![image](https://user-images.githubusercontent.com/20326645/60106306-fbca2a00-9732-11e9-91b6-b0ae9d6fa98d.png)

For this error range, I simply used the start tag name for the given offset.

The arguments were:
```
arguments[0] = "simpleType"
arguments[1] = "(annotation?, (restriction | list | union))"
```

Signed-off-by: David Kwon <dakwon@redhat.com>