### PR TITLE
Fix error range for ct-props-correct.3 when attribute value has a namespace

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
@@ -102,9 +102,11 @@ public enum XSDErrorCode implements IXMLErrorCode {
 			return XMLPositionUtility.selectAttributeValueAt("maxOccurs", offset, document);
 		}
 		case ct_props_correct_3: {
-			String argument = (String) arguments[0];
-			String attrName = argument.substring(argument.indexOf(":") + 1);
-			return XMLPositionUtility.selectAttributeValueFromGivenValue(attrName, offset, document);
+			String attrValue = (String) arguments[0];
+			if (attrValue.charAt(0) == ':') {
+				attrValue = attrValue.substring(1);
+			}
+			return XMLPositionUtility.selectAttributeValueFromGivenValue(attrValue, offset, document);
 		}
 		case p_props_correct_2_1:
 			return XMLPositionUtility.selectAttributeFromGivenNameAt("minOccurs", offset, document);

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
@@ -62,7 +62,7 @@ public class XSDValidationExtensionsTest {
 	}
 
 	@Test
-	public void ct_props_correct_3() throws BadLocationException {
+	public void ct_props_correct_3_1() throws BadLocationException {
 		String xml = "<?xml version=\"1.1\" ?>\r\n" +
 			"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\" attributeFormDefault=\"unqualified\">\r\n" +
 			"	<xs:complexType name=\"fullpersoninfo\">\r\n" +
@@ -73,6 +73,19 @@ public class XSDValidationExtensionsTest {
 			"	</xs:complexType>\r\n" +
 			"</xs:schema>";
 		testDiagnosticsFor(xml, d(4, 22, 4, 38, XSDErrorCode.ct_props_correct_3));
+	}
+
+	@Test
+	public void ct_props_correct_3_2() throws BadLocationException {
+		String xml = "<?xml version=\"1.1\" ?>\r\n" +
+			"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"http://www.w3.org/2001/XMLSchema\">\r\n" +
+			"	<xs:complexType name=\"aComplexType\">\r\n" +
+			"		<xs:complexContent>\r\n" +
+			"			<xs:extension base=\"xs:aComplexType\"></xs:extension>\r\n" +
+			"		</xs:complexContent>\r\n" +
+			"	</xs:complexType>\r\n" +
+			"</xs:schema>";
+		testDiagnosticsFor(xml, d(4, 22, 4, 39, XSDErrorCode.ct_props_correct_3));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #467 

![image](https://user-images.githubusercontent.com/20326645/60132315-3f3f8b00-9769-11e9-9444-f1c8f3b7043c.png)

Previously, the error range was incorrect when the attribute value had a namespace.
This PR fixes the range, and considers both the case where the value has a namespace, and doesn't.

Signed-off-by: David Kwon <dakwon@redhat.com>