### PR TITLE
Fix error range for sch-props-correct.2

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
@@ -40,6 +40,7 @@ public enum XSDErrorCode implements IXMLErrorCode {
 	s4s_att_not_allowed("s4s-att-not-allowed"), //
 	s4s_att_invalid_value("s4s-att-invalid-value"), //
 	s4s_elt_character("s4s-elt-character"), //
+	sch_props_correct_2("sch-props-correct.2"),
 	src_ct_1("src-ct.1"),
 	src_element_3("src-element.3"),
 	src_resolve_4_2("src-resolve.4.2"), //
@@ -128,7 +129,12 @@ public enum XSDErrorCode implements IXMLErrorCode {
 		}
 		case s4s_elt_character:
 			return XMLPositionUtility.selectContent(offset, document);
-		case src_ct_1: 
+		case sch_props_correct_2: {
+			String argument = (String) arguments[0];
+			String attrName = argument.substring(argument.indexOf(",") + 1);
+			return XMLPositionUtility.selectAttributeValueFromGivenValue(attrName, offset, document);
+		}
+		case src_ct_1:
 			return XMLPositionUtility.selectAttributeValueAt("base", offset, document);
 		case src_resolve_4_2: {
 			String attrValue = (String) arguments[2];

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
@@ -181,6 +181,16 @@ public class XSDValidationExtensionsTest {
 	}
 
 	@Test
+	public void sch_props_correct_2() throws BadLocationException {
+		String xml = "<?xml version=\"1.1\" ?>\r\n" +
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n" +
+				"	<xs:element name=\"elt1\" />\r\n" +
+				"	<xs:element name=\"elt1\" />\r\n" +
+				"</xs:schema>";
+		testDiagnosticsFor(xml, d(3, 18, 3, 24, XSDErrorCode.sch_props_correct_2));
+	}
+
+	@Test
 	public void src_ct_1() throws BadLocationException {
 		String xml = "<?xml version=\"1.1\" ?>\r\n" +
 				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" elementFormDefault=\"qualified\" attributeFormDefault=\"unqualified\">\r\n" +


### PR DESCRIPTION
Fixes #462

![image](https://user-images.githubusercontent.com/20326645/60301207-bb1f0c00-98fe-11e9-86aa-3710871d8e1f.png)

The only argument provided by xerces was:
`arguments[0] = ",elt1"`

From the xerces source code, it looks like if a namespace exists, it gets placed right before the attribute value:
https://github.com/apache/xerces2-j/blob/cf0c517a41b31b0242b96ab1af9627a3ab07fcd2/src/org/apache/xerces/impl/xs/traversers/XSDHandler.java#L3384-L3389

I'm not sure if I interpreted this correctly, but I tried to take into account the situation where a namespace does exist:
https://github.com/xorye/lsp4xml/blob/be47ec532e8b566b1c779efe50253fc18e41216c/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java#L137

I did not add a test case for that specific situation, because I'm not very sure how to add a namespace and create a `sch-props-correct.2` error at the same time.

Signed-off-by: David Kwon <dakwon@redhat.com>