### PR TITLE
XSD CodeLens references should be clickable

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLLanguageServer.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLLanguageServer.java
@@ -30,6 +30,7 @@ import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
+import org.eclipse.lsp4xml.client.ExtendedClientCapabilities;
 import org.eclipse.lsp4xml.commons.ModelTextDocument;
 import org.eclipse.lsp4xml.commons.ParentProcessWatcher.ProcessLanguageServer;
 import org.eclipse.lsp4xml.customservice.AutoCloseTagResponse;
@@ -52,6 +53,7 @@ import org.eclipse.lsp4xml.settings.XMLFormattingOptions;
 import org.eclipse.lsp4xml.settings.XMLGeneralClientSettings;
 import org.eclipse.lsp4xml.settings.XMLIncrementalSupportSettings;
 import org.eclipse.lsp4xml.settings.XMLSymbolSettings;
+import org.eclipse.lsp4xml.settings.capabilities.InitializationOptionsExtendedClientCapabilities;
 import org.eclipse.lsp4xml.settings.capabilities.ServerCapabilitiesInitializer;
 import org.eclipse.lsp4xml.settings.capabilities.XMLCapabilityManager;
 import org.eclipse.lsp4xml.utils.FilesUtils;
@@ -89,10 +91,13 @@ public class XMLLanguageServer
 		// Update XML language service extensions with InitializeParams
 		xmlLanguageService.initializeParams(params);
 
-		capabilityManager.setClientCapabilities(params.getCapabilities());
+		ExtendedClientCapabilities extendedClientCapabilities = InitializationOptionsExtendedClientCapabilities
+				.getExtendedClientCapabilities(params);
+		capabilityManager.setClientCapabilities(params.getCapabilities(), extendedClientCapabilities);
 		updateSettings(InitializationOptionsSettings.getSettings(params));
 
-		xmlTextDocumentService.updateClientCapabilities(capabilityManager.getClientCapabilities().capabilities);
+		xmlTextDocumentService.updateClientCapabilities(capabilityManager.getClientCapabilities().capabilities,
+				capabilityManager.getClientCapabilities().getExtendedCapabilities());
 		ServerCapabilities nonDynamicServerCapabilities = ServerCapabilitiesInitializer.getNonDynamicServerCapabilities(
 				capabilityManager.getClientCapabilities(), xmlTextDocumentService.isIncrementalSupport());
 

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLTextDocumentService.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLTextDocumentService.java
@@ -64,6 +64,7 @@ import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.TextDocumentService;
+import org.eclipse.lsp4xml.client.ExtendedClientCapabilities;
 import org.eclipse.lsp4xml.commons.ModelTextDocument;
 import org.eclipse.lsp4xml.commons.ModelTextDocuments;
 import org.eclipse.lsp4xml.commons.TextDocument;
@@ -143,7 +144,7 @@ public class XMLTextDocumentService implements TextDocumentService {
 		this.sharedSettings = new SharedSettings();
 	}
 
-	public void updateClientCapabilities(ClientCapabilities capabilities) {
+	public void updateClientCapabilities(ClientCapabilities capabilities, ExtendedClientCapabilities extendedClientCapabilities) {
 		TextDocumentClientCapabilities textDocumentClientCapabilities = capabilities.getTextDocument();
 		if (textDocumentClientCapabilities != null) {
 			// Completion settings
@@ -156,6 +157,10 @@ public class XMLTextDocumentService implements TextDocumentService {
 			definitionLinkSupport = textDocumentClientCapabilities.getDefinition() != null
 					&& textDocumentClientCapabilities.getDefinition().getLinkSupport() != null
 					&& textDocumentClientCapabilities.getDefinition().getLinkSupport();
+		}
+		if (extendedClientCapabilities != null) {
+			// Extended client capabilities
+			sharedSettings.getCodeLensSettings().setCodeLens(extendedClientCapabilities.getCodeLens());			
 		}
 	}
 
@@ -314,7 +319,7 @@ public class XMLTextDocumentService implements TextDocumentService {
 			return CompletableFuture.completedFuture(Collections.emptyList());
 		}
 		return computeDOMAsync(params.getTextDocument(), (cancelChecker, xmlDocument) -> {
-			return getXMLLanguageService().getCodeLens(xmlDocument, cancelChecker);
+			return getXMLLanguageService().getCodeLens(xmlDocument, sharedSettings.getCodeLensSettings(), cancelChecker);
 		});
 	}
 

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/client/ClientCommands.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/client/ClientCommands.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.client;
+
+/**
+ * Commonly used client commands
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public class ClientCommands {
+
+	private ClientCommands() {
+	}
+
+	/**
+	 * Show references
+	 */
+	public static final String SHOW_REFERENCES = "xml.show.references";
+
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/client/CodeLensKind.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/client/CodeLensKind.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.client;
+
+/**
+ * CodeLens kind supported by the client.
+ * 
+ * @author Angelo ZERR
+ * 
+ * @see https://github.com/microsoft/language-server-protocol/issues/788
+ */
+public class CodeLensKind {
+
+	private CodeLensKind() {
+	}
+
+	public static final String References = "references";
+
+	public static final String Implementations = "implementations";
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/client/CodeLensKindCapabilities.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/client/CodeLensKindCapabilities.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.client;
+
+import java.util.List;
+
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Specific capabilities for the `CodeLensKind`.
+ * 
+ * @see https://github.com/microsoft/language-server-protocol/issues/788
+ */
+@SuppressWarnings("all")
+public class CodeLensKindCapabilities {
+	/**
+	 * The codeLens kind values the client supports. When this property exists the
+	 * client also guarantees that it will handle values outside its set gracefully
+	 * and falls back to a default value when unknown.
+	 * 
+	 * If this property is not present the client only supports the codeLens kinds
+	 * from `File` to `Array` as defined in the initial version of the protocol.
+	 */
+	private List<String> valueSet;
+
+	public CodeLensKindCapabilities() {
+	}
+
+	public CodeLensKindCapabilities(final List<String> valueSet) {
+		this.valueSet = valueSet;
+	}
+
+	/**
+	 * The codeLens kind values the client supports. When this property exists the
+	 * client also guarantees that it will handle values outside its set gracefully
+	 * and falls back to a default value when unknown.
+	 * 
+	 * If this property is not present the client only supports the codeLens kinds
+	 * from `File` to `Array` as defined in the initial version of the protocol.
+	 */
+	@Pure
+	public List<String> getValueSet() {
+		return this.valueSet;
+	}
+
+	/**
+	 * The codeLens kind values the client supports. When this property exists the
+	 * client also guarantees that it will handle values outside its set gracefully
+	 * and falls back to a default value when unknown.
+	 * 
+	 * If this property is not present the client only supports the codeLens kinds
+	 * from `File` to `Array` as defined in the initial version of the protocol.
+	 */
+	public void setValueSet(final List<String> valueSet) {
+		this.valueSet = valueSet;
+	}
+
+	@Override
+	@Pure
+	public String toString() {
+		ToStringBuilder b = new ToStringBuilder(this);
+		b.add("valueSet", this.valueSet);
+		return b.toString();
+	}
+
+	@Override
+	@Pure
+	public boolean equals(final Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		CodeLensKindCapabilities other = (CodeLensKindCapabilities) obj;
+		if (this.valueSet == null) {
+			if (other.valueSet != null)
+				return false;
+		} else if (!this.valueSet.equals(other.valueSet))
+			return false;
+		return true;
+	}
+
+	@Override
+	@Pure
+	public int hashCode() {
+		return 31 * 1 + ((this.valueSet == null) ? 0 : this.valueSet.hashCode());
+	}
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/client/ExtendedClientCapabilities.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/client/ExtendedClientCapabilities.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.client;
+
+/**
+ * Extended client capabilities not defined by the LSP.
+ * 
+ * @author Angelo ZERR
+ * 
+ * @see https://github.com/microsoft/language-server-protocol/issues/788
+ */
+public class ExtendedClientCapabilities {
+
+	private ExtendedCodeLensCapabilities codeLens;
+
+	public ExtendedCodeLensCapabilities getCodeLens() {
+		return codeLens;
+	}
+
+	public void setCodeLens(ExtendedCodeLensCapabilities codeLens) {
+		this.codeLens = codeLens;
+	}
+
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/client/ExtendedCodeLensCapabilities.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/client/ExtendedCodeLensCapabilities.java
@@ -1,0 +1,100 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.client;
+
+import org.eclipse.lsp4j.DynamicRegistrationCapabilities;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Extended capabilities specific to the `textDocument/codeLens` request. This capability doesn't belong to LSP specification. See proposal at 
+ * https://github.com/microsoft/language-server-protocol/issues/788
+ * 
+ * @author Angelo ZERR
+ * 
+ * @see https://github.com/microsoft/language-server-protocol/issues/788
+ */
+@SuppressWarnings("all")
+public class ExtendedCodeLensCapabilities extends DynamicRegistrationCapabilities {
+	/**
+	 * Specific capabilities for the `CodeLensKind` in the `textDocument/codeLens`
+	 * request.
+	 */
+	private CodeLensKindCapabilities codeLensKind;
+
+	public ExtendedCodeLensCapabilities() {
+	}
+
+	public ExtendedCodeLensCapabilities(final Boolean dynamicRegistration) {
+		super(dynamicRegistration);
+	}
+
+	public ExtendedCodeLensCapabilities(final CodeLensKindCapabilities codeLensKind) {
+		this.codeLensKind = codeLensKind;
+	}
+
+	public ExtendedCodeLensCapabilities(final CodeLensKindCapabilities codeLensKind,
+			final Boolean dynamicRegistration) {
+		super(dynamicRegistration);
+		this.codeLensKind = codeLensKind;
+	}
+
+	/**
+	 * Specific capabilities for the `CodeLensKind` in the `textDocument/codeLens`
+	 * request.
+	 */
+	@Pure
+	public CodeLensKindCapabilities getCodeLensKind() {
+		return this.codeLensKind;
+	}
+
+	/**
+	 * Specific capabilities for the `CodeLensKind` in the `textDocument/codeLens`
+	 * request.
+	 */
+	public void setCodeLensKind(final CodeLensKindCapabilities codeLensKind) {
+		this.codeLensKind = codeLensKind;
+	}
+
+	@Override
+	@Pure
+	public String toString() {
+		ToStringBuilder b = new ToStringBuilder(this);
+		b.add("codeLensKind", this.codeLensKind);
+		b.add("dynamicRegistration", getDynamicRegistration());
+		return b.toString();
+	}
+
+	@Override
+	@Pure
+	public boolean equals(final Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		if (!super.equals(obj))
+			return false;
+		ExtendedCodeLensCapabilities other = (ExtendedCodeLensCapabilities) obj;
+		if (this.codeLensKind == null) {
+			if (other.codeLensKind != null)
+				return false;
+		} else if (!this.codeLensKind.equals(other.codeLensKind))
+			return false;
+		return true;
+	}
+
+	@Override
+	@Pure
+	public int hashCode() {
+		return 31 * super.hashCode() + ((this.codeLensKind == null) ? 0 : this.codeLensKind.hashCode());
+	}
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDCodeLensParticipant.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDCodeLensParticipant.java
@@ -9,17 +9,23 @@
 *******************************************************************************/
 package org.eclipse.lsp4xml.extensions.xsd.participants;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.eclipse.lsp4xml.client.ClientCommands;
+import org.eclipse.lsp4xml.client.CodeLensKind;
 import org.eclipse.lsp4xml.dom.DOMDocument;
 import org.eclipse.lsp4xml.dom.DOMElement;
 import org.eclipse.lsp4xml.extensions.xsd.utils.XSDUtils;
 import org.eclipse.lsp4xml.services.extensions.ICodeLensParticipant;
+import org.eclipse.lsp4xml.services.extensions.ICodeLensRequest;
 import org.eclipse.lsp4xml.utils.DOMUtils;
 import org.eclipse.lsp4xml.utils.XMLPositionUtility;
 
@@ -33,26 +39,35 @@ public class XSDCodeLensParticipant implements ICodeLensParticipant {
 
 	static class ReferenceCommand extends Command {
 
-		private transient int nbReferences;
+		private transient int nbReferences = 1;
 
-		public ReferenceCommand() {
-			nbReferences = 1;
-			super.setTitle(nbReferences + " reference");
+		public ReferenceCommand(String uri, Position position, boolean supportedByClient) {
+			super(getTitle(1), supportedByClient ? ClientCommands.SHOW_REFERENCES : "");
+			super.setArguments(Arrays.asList(uri, position));
 		}
 
 		public void increment() {
 			nbReferences++;
-			super.setTitle(nbReferences + " references");
+			super.setTitle(getTitle(nbReferences));
+		}
+
+		private static String getTitle(int nbReferences) {
+			if (nbReferences == 1) {
+				return nbReferences + " reference";
+			}
+			return nbReferences + " references";
 		}
 
 	}
 
 	@Override
-	public void doCodeLens(DOMDocument xmlDocument, List<CodeLens> lenses, CancelChecker cancelChecker) {
+	public void doCodeLens(ICodeLensRequest request, List<CodeLens> lenses, CancelChecker cancelChecker) {
+		DOMDocument xmlDocument = request.getDocument();
 		// XSD types CodeLens is applicable only for XML Schema file
 		if (!DOMUtils.isXSD(xmlDocument)) {
 			return;
 		}
+		boolean supportedByClient = request.isSupportedByClient(CodeLensKind.References);
 		// Add references CodeLens for each xs:simpleType, xs:complexType, xs:element,
 		// xs:group root element.
 		Map<DOMElement, CodeLens> cache = new HashMap<>();
@@ -61,9 +76,9 @@ public class XSDCodeLensParticipant implements ICodeLensParticipant {
 			DOMElement targetElement = target.getOwnerElement();
 			CodeLens codeLens = cache.get(targetElement);
 			if (codeLens == null) {
-				codeLens = new CodeLens(
-						XMLPositionUtility.createRange(target.getStart(), target.getEnd(), xmlDocument));
-				codeLens.setCommand(new ReferenceCommand());
+				Range range = XMLPositionUtility.createRange(target.getStart(), target.getEnd(), xmlDocument);
+				codeLens = new CodeLens(range);
+				codeLens.setCommand(new ReferenceCommand(xmlDocument.getDocumentURI(), range.getStart(), supportedByClient));
 				cache.put(targetElement, codeLens);
 				lenses.add(codeLens);
 			} else {

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/CodeLensRequest.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/CodeLensRequest.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.services;
+
+import org.eclipse.lsp4xml.dom.DOMDocument;
+import org.eclipse.lsp4xml.services.extensions.ICodeLensRequest;
+import org.eclipse.lsp4xml.settings.XMLCodeLensSettings;
+
+/**
+ * CodeLens request
+ * 
+ * @author Angelo ZERR
+ *
+ */
+class CodeLensRequest implements ICodeLensRequest {
+
+	private final DOMDocument document;
+
+	private final XMLCodeLensSettings settings;
+
+	public CodeLensRequest(DOMDocument document, XMLCodeLensSettings settings) {
+		this.document = document;
+		this.settings = settings;
+	}
+
+	@Override
+	public DOMDocument getDocument() {
+		return document;
+	}
+
+	@Override
+	public boolean isSupportedByClient(String kind) {
+		return settings.isSupportedByClient(kind);
+	}
+
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLCodeLens.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLCodeLens.java
@@ -17,7 +17,9 @@ import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4xml.dom.DOMDocument;
 import org.eclipse.lsp4xml.services.extensions.ICodeLensParticipant;
+import org.eclipse.lsp4xml.services.extensions.ICodeLensRequest;
 import org.eclipse.lsp4xml.services.extensions.XMLExtensionsRegistry;
+import org.eclipse.lsp4xml.settings.XMLCodeLensSettings;
 
 /**
  * XML Code Lens support.
@@ -31,10 +33,11 @@ class XMLCodeLens {
 		this.extensionsRegistry = extensionsRegistry;
 	}
 
-	public List<? extends CodeLens> getCodelens(DOMDocument xmlDocument, CancelChecker cancelChecker) {
+	public List<? extends CodeLens> getCodelens(DOMDocument xmlDocument, XMLCodeLensSettings settings, CancelChecker cancelChecker) {
+		ICodeLensRequest request = new CodeLensRequest(xmlDocument, settings);
 		List<CodeLens> lenses = new ArrayList<>();
 		for (ICodeLensParticipant participant : extensionsRegistry.getCodeLensParticipants()) {
-			participant.doCodeLens(xmlDocument, lenses, cancelChecker);
+			participant.doCodeLens(request, lenses, cancelChecker);
 		}
 		return lenses;
 	}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLLanguageService.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLLanguageService.java
@@ -46,6 +46,7 @@ import org.eclipse.lsp4xml.dom.DOMElement;
 import org.eclipse.lsp4xml.extensions.contentmodel.settings.XMLValidationSettings;
 import org.eclipse.lsp4xml.services.extensions.XMLExtensionsRegistry;
 import org.eclipse.lsp4xml.settings.SharedSettings;
+import org.eclipse.lsp4xml.settings.XMLCodeLensSettings;
 import org.eclipse.lsp4xml.settings.XMLFormattingOptions;
 import org.eclipse.lsp4xml.uriresolver.CacheResourceDownloadingException;
 import org.eclipse.lsp4xml.utils.XMLPositionUtility;
@@ -217,8 +218,8 @@ public class XMLLanguageService extends XMLExtensionsRegistry {
 		return reference.findReferences(xmlDocument, position, context, cancelChecker);
 	}
 
-	public List<? extends CodeLens> getCodeLens(DOMDocument xmlDocument, CancelChecker cancelChecker) {
-		return codelens.getCodelens(xmlDocument, cancelChecker);
+	public List<? extends CodeLens> getCodeLens(DOMDocument xmlDocument, XMLCodeLensSettings settings, CancelChecker cancelChecker) {
+		return codelens.getCodelens(xmlDocument, settings, cancelChecker);
 	}
 
 	public List<CodeAction> doCodeActions(CodeActionContext context, Range range, DOMDocument document,

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/ICodeLensParticipant.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/ICodeLensParticipant.java
@@ -4,10 +4,9 @@ import java.util.List;
 
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
-import org.eclipse.lsp4xml.dom.DOMDocument;
 
 public interface ICodeLensParticipant {
 
-	void doCodeLens(DOMDocument xmlDocument, List<CodeLens> lenses, CancelChecker cancelChecker);
+	void doCodeLens(ICodeLensRequest request, List<CodeLens> lenses, CancelChecker cancelChecker);
 
 }

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/ICodeLensRequest.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/ICodeLensRequest.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.services.extensions;
+
+import org.eclipse.lsp4xml.dom.DOMDocument;
+
+/**
+ * CodeLens request API.
+ * 
+ * @author Angelo ZERR
+ *
+ */
+public interface ICodeLensRequest {
+
+	/**
+	 * Returns the DOM document.
+	 * 
+	 * @return the DOM document
+	 */
+	DOMDocument getDocument();
+
+	/**
+	 * Returns true if the given code lens kind is supported by the client and false
+	 * otherwise.
+	 * 
+	 * @param kind code lens kind
+	 * @return true if the given code lens kind is supported by the client and false
+	 *         otherwise.
+	 */
+	boolean isSupportedByClient(String kind);
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/XMLCodeLensSettings.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/XMLCodeLensSettings.java
@@ -9,6 +9,8 @@
 *******************************************************************************/
 package org.eclipse.lsp4xml.settings;
 
+import org.eclipse.lsp4xml.client.ExtendedCodeLensCapabilities;
+
 /**
  * XML CodeLens settings
  * 
@@ -19,11 +21,46 @@ public class XMLCodeLensSettings {
 
 	private boolean enabled = false;
 
+	private ExtendedCodeLensCapabilities codeLens;
+
+	/**
+	 * Returns true if codelens service is enabled and false otherwise.
+	 * 
+	 * @return true if codelens service is enabled and false otherwise.
+	 */
 	public boolean isEnabled() {
 		return enabled;
 	}
 
+	/**
+	 * Set true if codelens service is enabled and false otherwise.
+	 * 
+	 * @param enabled
+	 */
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
+	}
+
+	/**
+	 * Returns true if the given code lens kind is supported by the client and false
+	 * otherwise.
+	 * 
+	 * @param kind code lens kind
+	 * @return true if the given code lens kind is supported by the client and false
+	 *         otherwise.
+	 */
+	public boolean isSupportedByClient(String kind) {
+		return codeLens != null && codeLens.getCodeLensKind() != null
+				&& codeLens.getCodeLensKind().getValueSet() != null
+				&& codeLens.getCodeLensKind().getValueSet().contains(kind);
+	}
+
+	/**
+	 * Update the codelens client capabilities.
+	 * 
+	 * @param codelens client capabilities
+	 */
+	public void setCodeLens(ExtendedCodeLensCapabilities codeLens) {
+		this.codeLens = codeLens;
 	}
 }

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/capabilities/ClientCapabilitiesWrapper.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/capabilities/ClientCapabilitiesWrapper.java
@@ -14,6 +14,7 @@ package org.eclipse.lsp4xml.settings.capabilities;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.DynamicRegistrationCapabilities;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+import org.eclipse.lsp4xml.client.ExtendedClientCapabilities;
 
 /**
  * Determines if a client supports a specific capability dynamically
@@ -23,14 +24,16 @@ public class ClientCapabilitiesWrapper {
 
 	public ClientCapabilities capabilities;
 
+	private final ExtendedClientCapabilities extendedCapabilities;
+
 	public ClientCapabilitiesWrapper() {
-		this.capabilities = new ClientCapabilities();
-		this.v3Supported = false;
+		this(new ClientCapabilities(), null);
 	}
 
-	public ClientCapabilitiesWrapper(ClientCapabilities capabilities) {
+	public ClientCapabilitiesWrapper(ClientCapabilities capabilities, ExtendedClientCapabilities extendedCapabilities) {
 		this.capabilities = capabilities;
 		this.v3Supported = capabilities != null ? capabilities.getTextDocument() != null : false;
+		this.extendedCapabilities = extendedCapabilities;
 	}
 
 	/**
@@ -75,11 +78,11 @@ public class ClientCapabilitiesWrapper {
 	public boolean isCodeLensDynamicRegistrationSupported() {
 		return v3Supported && isDynamicRegistrationSupported(getTextDocument().getCodeLens());
 	}
-	
+
 	public boolean isDefinitionDynamicRegistered() {
 		return v3Supported && isDynamicRegistrationSupported(getTextDocument().getDefinition());
 	}
-	
+
 	public boolean isReferencesDynamicRegistrationSupported() {
 		return v3Supported && isDynamicRegistrationSupported(getTextDocument().getReferences());
 	}
@@ -95,7 +98,7 @@ public class ClientCapabilitiesWrapper {
 	public boolean isDocumentHighlightDynamicRegistered() {
 		return v3Supported && isDynamicRegistrationSupported(getTextDocument().getDocumentHighlight());
 	}
-	
+
 	private boolean isDynamicRegistrationSupported(DynamicRegistrationCapabilities capability) {
 		return capability != null && capability.getDynamicRegistration() != null
 				&& capability.getDynamicRegistration().booleanValue();
@@ -105,4 +108,7 @@ public class ClientCapabilitiesWrapper {
 		return this.capabilities.getTextDocument();
 	}
 
+	public ExtendedClientCapabilities getExtendedCapabilities() {
+		return extendedCapabilities;
+	}
 }

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/capabilities/InitializationOptionsExtendedClientCapabilities.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/capabilities/InitializationOptionsExtendedClientCapabilities.java
@@ -1,0 +1,75 @@
+/**
+ *  Copyright (c) 2018 Angelo ZERR.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v2.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v20.html
+ *
+ *  Contributors:
+ *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ */
+
+package org.eclipse.lsp4xml.settings.capabilities;
+
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4xml.client.ExtendedClientCapabilities;
+import org.eclipse.lsp4xml.utils.JSONUtility;
+
+/**
+ * Represents all extended client capabilities sent from the server
+ * 
+ * <pre>
+ * "extendedClientCapabilities": {
+      "codeLens": {
+        "codeLensKind": {
+          "valueSet": [
+            "references"
+          ]
+        }
+      }
+    }
+ * </pre>
+ */
+public class InitializationOptionsExtendedClientCapabilities {
+
+	private ExtendedClientCapabilities extendedClientCapabilities;
+
+	public ExtendedClientCapabilities getExtendedClientCapabilities() {
+		return extendedClientCapabilities;
+	}
+
+	public void setExtendedClientCapabilities(ExtendedClientCapabilities extendedClientCapabilities) {
+		this.extendedClientCapabilities = extendedClientCapabilities;
+	}
+
+	/**
+	 * Returns the "settings" section of
+	 * {@link InitializeParams#getInitializationOptions()}.
+	 * 
+	 * Here a sample of initializationOptions
+	 * 
+	 * <pre>
+	 * "initializationOptions": {
+	 * 		"settings": {...}
+			"extendedClientCapabilities": {
+	          "codeLens": {
+	            "codeLensKind": {
+	              "valueSet": [
+	                "references"
+	              ]
+	            }
+	          }
+	        }
+		}
+	 * </pre>
+	 * 
+	 * @param initializeParams
+	 * @return the "extendedClientCapabilities" section of
+	 *         {@link InitializeParams#getInitializationOptions()}.
+	 */
+	public static ExtendedClientCapabilities getExtendedClientCapabilities(InitializeParams initializeParams) {
+		InitializationOptionsExtendedClientCapabilities root = JSONUtility.toModel(
+				initializeParams.getInitializationOptions(), InitializationOptionsExtendedClientCapabilities.class);
+		return root != null ? root.getExtendedClientCapabilities() : null;
+	}
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/capabilities/XMLCapabilityManager.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/capabilities/XMLCapabilityManager.java
@@ -48,6 +48,7 @@ import org.eclipse.lsp4j.Unregistration;
 import org.eclipse.lsp4j.UnregistrationParams;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4xml.XMLTextDocumentService;
+import org.eclipse.lsp4xml.client.ExtendedClientCapabilities;
 import org.eclipse.lsp4xml.settings.XMLCodeLensSettings;
 import org.eclipse.lsp4xml.settings.XMLFormattingOptions;
 import org.eclipse.lsp4xml.settings.XMLSymbolSettings;
@@ -61,10 +62,11 @@ import org.eclipse.lsp4xml.settings.XMLSymbolSettings;
  */
 public class XMLCapabilityManager {
 
+	private final Set<String> registeredCapabilities = new HashSet<>(3);
+	private final LanguageClient languageClient;
+	private final XMLTextDocumentService textDocumentService;
+
 	private ClientCapabilitiesWrapper clientWrapper;
-	private Set<String> registeredCapabilities = new HashSet<>(3);
-	private LanguageClient languageClient;
-	private XMLTextDocumentService textDocumentService;
 
 	public XMLCapabilityManager(LanguageClient languageClient, XMLTextDocumentService textDocumentService) {
 		this.languageClient = languageClient;
@@ -76,9 +78,11 @@ public class XMLCapabilityManager {
 	 * clientCapabilities
 	 * 
 	 * @param clientCapabilities
+	 * @param extendedClientCapabilities
 	 */
-	public void setClientCapabilities(ClientCapabilities clientCapabilities) {
-		this.clientWrapper = new ClientCapabilitiesWrapper(clientCapabilities);
+	public void setClientCapabilities(ClientCapabilities clientCapabilities,
+			ExtendedClientCapabilities extendedClientCapabilities) {
+		this.clientWrapper = new ClientCapabilitiesWrapper(clientCapabilities, extendedClientCapabilities);
 	}
 
 	public ClientCapabilitiesWrapper getClientCapabilities() {

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/XMLAssert.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/XMLAssert.java
@@ -49,6 +49,10 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4xml.client.CodeLensKind;
+import org.eclipse.lsp4xml.client.CodeLensKindCapabilities;
+import org.eclipse.lsp4xml.client.ExtendedClientCapabilities;
+import org.eclipse.lsp4xml.client.ExtendedCodeLensCapabilities;
 import org.eclipse.lsp4xml.commons.BadLocationException;
 import org.eclipse.lsp4xml.commons.TextDocument;
 import org.eclipse.lsp4xml.customservice.AutoCloseTagResponse;
@@ -61,6 +65,7 @@ import org.eclipse.lsp4xml.services.extensions.CompletionSettings;
 import org.eclipse.lsp4xml.services.extensions.diagnostics.IXMLErrorCode;
 import org.eclipse.lsp4xml.services.extensions.save.AbstractSaveContext;
 import org.eclipse.lsp4xml.settings.SharedSettings;
+import org.eclipse.lsp4xml.settings.XMLCodeLensSettings;
 import org.eclipse.lsp4xml.settings.XMLFormattingOptions;
 import org.eclipse.lsp4xml.utils.StringUtils;
 import org.junit.Assert;
@@ -726,16 +731,18 @@ public class XMLAssert {
 				xmlLanguageService.getResolverExtensionManager());
 		xmlLanguageService.setDocumentProvider((uri) -> xmlDocument);
 
-		List<? extends CodeLens> actual = xmlLanguageService.getCodeLens(xmlDocument, () -> {
+		XMLCodeLensSettings codeLensSettings = new XMLCodeLensSettings();
+		ExtendedCodeLensCapabilities codeLensCapabilities = new ExtendedCodeLensCapabilities(
+				new CodeLensKindCapabilities(Arrays.asList(CodeLensKind.References)));
+		codeLensSettings.setCodeLens(codeLensCapabilities);
+		List<? extends CodeLens> actual = xmlLanguageService.getCodeLens(xmlDocument, codeLensSettings, () -> {
 		});
 		assertCodeLens(actual, expected);
 
 	}
 
-	public static CodeLens cl(Range range, String title) {
-		Command command = new Command();
-		command.setTitle(title);
-		return new CodeLens(range, command, null);
+	public static CodeLens cl(Range range, String title, String command) {
+		return new CodeLens(range, new Command(title, command), null);
 	}
 
 	public static void assertCodeLens(List<? extends CodeLens> actual, CodeLens... expected) {

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDCodeLensExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDCodeLensExtensionsTest.java
@@ -11,6 +11,7 @@ package org.eclipse.lsp4xml.extensions.xsd;
 
 import static org.eclipse.lsp4xml.XMLAssert.cl;
 import static org.eclipse.lsp4xml.XMLAssert.r;
+import static org.eclipse.lsp4xml.client.ClientCommands.SHOW_REFERENCES;
 
 import org.eclipse.lsp4xml.XMLAssert;
 import org.eclipse.lsp4xml.commons.BadLocationException;
@@ -41,7 +42,8 @@ public class XSDCodeLensExtensionsTest {
 				"	</xs:group>\r\n" + //
 				"	\r\n" + //
 				"</xs:schema>";
-		XMLAssert.testCodeLensFor(xml, cl(r(2, 13, 2, 23), "2 references"), cl(r(11, 11, 11, 21), "1 reference"));
+		XMLAssert.testCodeLensFor(xml, cl(r(2, 13, 2, 23), "2 references", SHOW_REFERENCES),
+				cl(r(11, 11, 11, 21), "1 reference", SHOW_REFERENCES));
 	}
 
 	@Test
@@ -67,7 +69,8 @@ public class XSDCodeLensExtensionsTest {
 				"		</xs:restriction>\r\n" + //
 				"	</xs:simpleType>\r\n" + //
 				"</xs:schema>";
-		XMLAssert.testCodeLensFor(xml, cl(r(3, 17, 3, 36), "2 references"), cl(r(15, 16, 15, 35), "1 reference"));
+		XMLAssert.testCodeLensFor(xml, cl(r(3, 17, 3, 36), "2 references", SHOW_REFERENCES),
+				cl(r(15, 16, 15, 35), "1 reference", SHOW_REFERENCES));
 	}
 
 }

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/settings/SettingsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/settings/SettingsTest.java
@@ -20,17 +20,21 @@ import static org.junit.Assert.fail;
 
 import java.io.File;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-
 import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4xml.XMLLanguageServer;
 import org.eclipse.lsp4xml.XMLTextDocumentService;
+import org.eclipse.lsp4xml.client.CodeLensKind;
+import org.eclipse.lsp4xml.client.ExtendedClientCapabilities;
 import org.eclipse.lsp4xml.extensions.contentmodel.settings.ContentModelSettings;
+import org.eclipse.lsp4xml.settings.capabilities.InitializationOptionsExtendedClientCapabilities;
 import org.eclipse.lsp4xml.utils.FilesUtils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
 /**
  * Tests for settings.
@@ -90,7 +94,16 @@ public class SettingsTest {
 	"				\"excluded\": [\"**\\\\*.xsd\", \"**\\\\*.xml\"]\r\n" + //
 	"			}\r\n" + 
 	"		}\r\n" + 
-	"	}\r\n" + 
+	"	}\r\n" +
+	"	,\"extendedClientCapabilities\": {\r\n" + 
+	"      \"codeLens\": {\r\n" + 
+	"        \"codeLensKind\": {\r\n" + 
+	"          \"valueSet\": [\r\n" + 
+	"            \"references\"\r\n" + 
+	"          ]\r\n" + 
+	"        }\r\n" + 
+	"      }\r\n" + 
+	"   }" +	
 	"}";
 	// @formatter:on
 
@@ -228,4 +241,17 @@ public class SettingsTest {
 		XMLTextDocumentService textDocumentService = (XMLTextDocumentService) languageServer.getTextDocumentService();
 	}
 
+	@Test
+	public void extendedClientCapabilitiesTest() {
+		InitializeParams params = createInitializeParams(json);
+		ExtendedClientCapabilities clientCapabilities = InitializationOptionsExtendedClientCapabilities
+				.getExtendedClientCapabilities(params);
+		Assert.assertNotNull(clientCapabilities);
+		Assert.assertNotNull(clientCapabilities.getCodeLens());
+		Assert.assertNotNull(clientCapabilities.getCodeLens().getCodeLensKind());
+		Assert.assertNotNull(clientCapabilities.getCodeLens().getCodeLensKind().getValueSet());
+		Assert.assertEquals(1, clientCapabilities.getCodeLens().getCodeLensKind().getValueSet().size());
+		Assert.assertEquals(CodeLensKind.References,
+				clientCapabilities.getCodeLens().getCodeLensKind().getValueSet().get(0));
+	}
 }

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/settings/capabilities/XMLCapabilitiesTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/settings/capabilities/XMLCapabilitiesTest.java
@@ -211,7 +211,7 @@ public class XMLCapabilitiesTest {
 
 	private void setAndInitializeCapabilities() {
 		clientCapabilities.setTextDocument(textDocument);
-		manager.setClientCapabilities(clientCapabilities);
+		manager.setClientCapabilities(clientCapabilities, null);
 		manager.initializeCapabilities();
 		capabilityIDs = manager.getRegisteredCapabilities();
 	}


### PR DESCRIPTION
Fix #490

This PR set XSD references CodeLens Command with "xml.show.references"
and uri, position as arguments.

Signed-off-by: azerr <azerr@redhat.com>