### PR TITLE
Remove indentation when formatting only whitespace

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLFormatter.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLFormatter.java
@@ -311,7 +311,6 @@ class XMLFormatter {
 						if (node.hasChildNodes()) {
 							// element has body
 							
-							// startElementClosed = true;
 							this.indentLevel++;
 							for (DOMNode child : node.getChildren()) {
 								boolean textElement = !child.isText();

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/XMLBuilder.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/XMLBuilder.java
@@ -242,7 +242,6 @@ public class XMLBuilder {
 				int newLineCount = StringUtils.getNumberOfNewLines(text, isWhitespaceContent, delimiter, preservedNewLines);				
 				for (int i = 0; i < newLineCount - 1; i++) { // - 1 because the node after will insert a delimiter
 					xml.append(delimiter);
-					this.indent(level);
 				}
 			}
 			

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLFormatterTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLFormatterTest.java
@@ -1137,11 +1137,11 @@ public class XMLFormatterTest {
 				"<!DOCTYPE note>\r\n" + 
 				"<note>\r\n" + 
 				"  <to>Fred</to>\r\n" +
-				"  \r\n" + 
+				"\r\n" + 
 				"  <from>Jani</from>\r\n" + 
-				"  \r\n" + 
+				"\r\n" + 
 				"  <heading>Reminder</heading>\r\n" + 
-				"  \r\n" + 
+				"\r\n" + 
 				"  <body>Don't forget me this weekend</body>\r\n" + 
 				"</note>";
 		format(content, expected, formattingOptions);
@@ -1209,10 +1209,10 @@ public class XMLFormatterTest {
 				"]>\r\n" + 
 				"<note>\r\n" + 
 				"  <to>Fred</to>\r\n" +
-				"  \r\n" +
-				"  \r\n" + 
+				"\r\n" +
+				"\r\n" + 
 				"  <from>Jani</from>\r\n" +
-				"  \r\n" + 
+				"\r\n" + 
 				"  <heading>Reminder</heading>\r\n" + 
 				"  <body>Don't forget me this weekend</body>\r\n" + 
 				"</note>";
@@ -1321,7 +1321,7 @@ public class XMLFormatterTest {
 				"]>\r\n" +
 				"\r\n" + 
 				"<note>\r\n" +
-				"  \r\n" + 
+				"\r\n" + 
 				"  <to>Fred</to>\r\n" + 
 				"</note>";
 		format(content, expected, formattingOptions);
@@ -1536,9 +1536,9 @@ public class XMLFormatterTest {
 				"]>\r\n" + 
 				"<web-app>\r\n" + 
 				"  <display-name>sdsd</display-name>\r\n" +
-				"  \r\n" + 
+				"\r\n" + 
 				"  <servlet>\r\n" + 
-				"    \r\n" + 
+				"\r\n" + 
 				"    <servlet-name>er</servlet-name>\r\n" + 
 				"    <servlet-class>dd</servlet-class>\r\n" + 
 				"  </servlet>\r\n" + 
@@ -2050,8 +2050,8 @@ public class XMLFormatterTest {
 		String expected = 
 				"<xml>\r\n" + 
 				"  <a></a>\r\n" + 
-				"  \r\n" +
-				"  \r\n" +
+				"\r\n" +
+				"\r\n" +
 				"</xml>";
 		format(content, expected, formattingOptions);
 	}
@@ -2070,9 +2070,9 @@ public class XMLFormatterTest {
 		String expected = 
 				"<xml>\r\n" + 
 				"  <a></a>\r\n" + 
-				"  \r\n" +
-				"  \r\n" +
-				"  \r\n" +
+				"\r\n" +
+				"\r\n" +
+				"\r\n" +
 				"</xml>";
 		format(content, expected, formattingOptions);
 	}
@@ -2091,8 +2091,8 @@ public class XMLFormatterTest {
 		String expected = 
 				"<xml>\r\n" + 
 				"  <a></a>\r\n" + 
-				"  \r\n" +
-				"  \r\n" +
+				"\r\n" +
+				"\r\n" +
 				"</xml>";
 		format(content, expected, formattingOptions);
 	}
@@ -2114,11 +2114,11 @@ public class XMLFormatterTest {
 				"</xml>";
 		String expected = 
 				"<xml>\r\n" + 
-				"  \r\n" +
-				"  \r\n" +
+				"\r\n" +
+				"\r\n" +
 				"  <a></a>\r\n" + 
-				"  \r\n" +
-				"  \r\n" +
+				"\r\n" +
+				"\r\n" +
 				"</xml>";
 		format(content, expected, formattingOptions);
 	}
@@ -2146,14 +2146,14 @@ public class XMLFormatterTest {
 				"</xml>";
 		String expected = 
 				"<xml>\r\n" + 
-				"  \r\n" +
-				"  \r\n" +
+				"\r\n" +
+				"\r\n" +
 				"  <a></a>\r\n" + 
-				"  \r\n" +
-				"  \r\n" +
+				"\r\n" +
+				"\r\n" +
 				"  <b></b>\r\n" + 
-				"  \r\n" +
-				"  \r\n" +
+				"\r\n" +
+				"\r\n" +
 				"</xml>";
 		format(content, expected, formattingOptions);
 	}
@@ -2169,7 +2169,7 @@ public class XMLFormatterTest {
 		String expected = 
 				"<xml>\r\n" + 
 				"  <a></a>\r\n" + 
-				"  \r\n" +
+				"\r\n" +
 				"</xml>";
 		format(content, expected, formattingOptions);
 	}
@@ -2188,6 +2188,29 @@ public class XMLFormatterTest {
 		format(content, expected, formattingOptions);
 	}
 
+	@Test 
+	public void testNoSpacesOnNewLine() throws BadLocationException {
+		XMLFormattingOptions formattingOptions = createDefaultFormattingOptions();
+		String content = 
+				"<a>\r\n" +
+				"  <b></b>\r\n" +
+				"\r\n" +
+				"\r\n" +
+				"  \r\n" +
+				"\r\n" +
+				"\r\n" +
+				"             \r\n" +
+				"\r\n" +
+				"\r\n" +
+				"</a>";
+		String expected = 
+				"<a>\r\n" +
+				"  <b></b>\r\n" +
+				"\r\n" +
+				"\r\n" +
+				"</a>";
+		format(content, expected, formattingOptions);
+	}
 	
 	
 	@Test 


### PR DESCRIPTION
Fixes https://github.com/redhat-developer/vscode-xml/issues/157

All I did was remove `this.indent(level);` from `XMLBuilder.java`.
After that change, about 10 tests failed because the tests expected spaces in empty lines, so I have edited those tests so that they do not expect the spacing.

Signed-off-by: David Kwon <dakwon@redhat.com>