### PR TITLE
Validate open .xml files when bounded .xsd files are externally saved

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLTextDocumentService.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLTextDocumentService.java
@@ -366,6 +366,11 @@ public class XMLTextDocumentService implements TextDocumentService {
 		doSave(context);
 	}
 
+	void doSave(String uri) {
+		SaveContext context = new SaveContext(uri);
+		doSave(context);
+	}
+
 	/**
 	 * Save settings or XML file.
 	 * 
@@ -465,6 +470,11 @@ public class XMLTextDocumentService implements TextDocumentService {
 	 */
 	public ModelTextDocument<DOMDocument> getDocument(String uri) {
 		return documents.get(uri);
+	}
+
+	public boolean documentIsOpen(String uri) {
+		ModelTextDocument<DOMDocument> document = getDocument(uri);
+		return document != null;
 	}
 
 	/**

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLWorkspaceService.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/XMLWorkspaceService.java
@@ -15,10 +15,11 @@ import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.FileEvent;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.services.WorkspaceService;
-
+import org.eclipse.lsp4xml.XMLTextDocumentService;
 /**
  * XML workspace service.
  *
@@ -44,9 +45,12 @@ public class XMLWorkspaceService implements WorkspaceService {
 
 	@Override
 	public void didChangeWatchedFiles(DidChangeWatchedFilesParams params) {
-
+		XMLTextDocumentService xmlTextDocumentService = (XMLTextDocumentService) xmlLanguageServer.getTextDocumentService();
+		List<FileEvent> changes = params.getChanges();
+		for (FileEvent change: changes) {
+			if (!xmlTextDocumentService.documentIsOpen(change.getUri())) {
+				xmlTextDocumentService.doSave(change.getUri());
+			}
+		}
 	}
-
-	
-
 }

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/ContentModelPlugin.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/ContentModelPlugin.java
@@ -56,17 +56,17 @@ public class ContentModelPlugin implements IXMLExtension {
 			// The save is done for a given XML file
 			String documentURI = context.getUri();
 			DOMDocument document = context.getDocument(documentURI);
-			if (DOMUtils.isCatalog(document)) {
+			if (document != null && DOMUtils.isCatalog(document)) {
 				// the XML document which has changed is a XML catalog.
 				// 1) refresh catalogs
 				contentModelManager.refreshCatalogs();
-				// 2) Validate all opened XML files except the catalog which have changed
-				context.collectDocumentToValidate(d -> {
-					DOMDocument xml = context.getDocument(d.getDocumentURI());
-					xml.resetGrammar();
-					return !documentURI.equals(d.getDocumentURI());
-				});
 			}
+			// 2) Validate all opened XML files except the catalog which have changed
+			context.collectDocumentToValidate(d -> {
+				DOMDocument xml = context.getDocument(d.getDocumentURI());
+				xml.resetGrammar();
+				return !documentURI.equals(d.getDocumentURI());
+			});
 		} else {
 			// Settings
 			updateSettings(context);
@@ -89,6 +89,9 @@ public class ContentModelPlugin implements IXMLExtension {
 				// Validate all opened XML files
 				context.collectDocumentToValidate(d -> {
 					DOMDocument xml = context.getDocument(d.getDocumentURI());
+					if (xml == null) {
+						return false;
+					}
 					xml.resetGrammar();
 					return true;
 				});

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/capabilities/ClientCapabilitiesWrapper.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/capabilities/ClientCapabilitiesWrapper.java
@@ -99,6 +99,10 @@ public class ClientCapabilitiesWrapper {
 		return v3Supported && isDynamicRegistrationSupported(getTextDocument().getDocumentHighlight());
 	}
 
+	public boolean isDidChangeWatchedFilesRegistered() {
+		return v3Supported && isDynamicRegistrationSupported(capabilities.getWorkspace().getDidChangeWatchedFiles());
+	}
+
 	private boolean isDynamicRegistrationSupported(DynamicRegistrationCapabilities capability) {
 		return capability != null && capability.getDynamicRegistration() != null
 				&& capability.getDynamicRegistration().booleanValue();

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/capabilities/XMLCapabilityManager.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/settings/capabilities/XMLCapabilityManager.java
@@ -36,12 +36,18 @@ import static org.eclipse.lsp4xml.settings.capabilities.ServerCapabilitiesConsta
 import static org.eclipse.lsp4xml.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_LINK;
 import static org.eclipse.lsp4xml.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_REFERENCES;
 import static org.eclipse.lsp4xml.settings.capabilities.ServerCapabilitiesConstants.TEXT_DOCUMENT_RENAME;
+import static org.eclipse.lsp4xml.settings.capabilities.ServerCapabilitiesConstants.WORKSPACE_WATCHED_FILES;
+import static org.eclipse.lsp4xml.settings.capabilities.ServerCapabilitiesConstants.WORKSPACE_WATCHED_FILES_ID;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions;
+import org.eclipse.lsp4j.FileSystemWatcher;
 import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.RegistrationParams;
 import org.eclipse.lsp4j.Unregistration;
@@ -153,7 +159,19 @@ public class XMLCapabilityManager {
 		if (this.getClientCapabilities().isReferencesDynamicRegistrationSupported()) {
 			registerCapability(REFERENCES_ID, TEXT_DOCUMENT_REFERENCES);
 		}
+		if (this.getClientCapabilities().isDidChangeWatchedFilesRegistered()) {
+			registerWatchedFiles();
+		}
+		
 		syncDynamicCapabilitiesWithPreferences();
+	}
+
+	private void registerWatchedFiles() {
+		List<FileSystemWatcher> watchers = new ArrayList<>(2);
+		watchers.add(new FileSystemWatcher("**/*.xsd"));
+		watchers.add(new FileSystemWatcher("**/*.dtd"));
+		DidChangeWatchedFilesRegistrationOptions options = new DidChangeWatchedFilesRegistrationOptions(watchers);
+		registerCapability(WORKSPACE_WATCHED_FILES_ID, WORKSPACE_WATCHED_FILES, options);
 	}
 
 	/**

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLExternalTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLExternalTest.java
@@ -1,0 +1,249 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.extensions.contentmodel;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import com.google.common.io.MoreFiles;
+
+import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.FileChangeType;
+import org.eclipse.lsp4j.FileEvent;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4xml.XMLLanguageServer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+/**
+ * This class tests the functionality where an XML file undergoes
+ * validation against its schema when the XSD schema file (or DTD file)
+ * has been modified and saved externally through means, not within 
+ * the LS client.
+ * 
+ * @author David Kwon
+ *
+ */
+public class XMLExternalTest {
+
+	private int threadSleepMs = 600;
+	
+	private static String tempDirPath = "./target/temp/";
+	private static URI tempDirUri = Paths.get(tempDirPath).toAbsolutePath().toUri();
+
+	private List<PublishDiagnosticsParams> actualDiagnostics;
+	private XMLLanguageServer languageServer;
+
+	@BeforeClass
+	public static void setup() throws FileNotFoundException, IOException {
+		deleteTempDirIfExists();
+		createTempDir();
+	}
+
+	@AfterClass
+	public static void tearDown() throws IOException {
+		deleteTempDirIfExists();
+	}
+
+	@Before
+	public void before() {
+		actualDiagnostics = new ArrayList<>();
+		languageServer = createServer(actualDiagnostics);
+	}
+
+	private static void deleteTempDirIfExists() throws IOException {
+		File tempDir = new File(tempDirUri);
+		if (tempDir.exists()) {
+			MoreFiles.deleteRecursively(tempDir.toPath());
+		}
+	}
+
+	private static void createTempDir() {
+		File tempDir = new File(tempDirUri);
+		tempDir.mkdir();
+	}
+
+	@Test
+	public void externalDTDTest() throws InterruptedException, IOException {
+		String dtdPath = tempDirUri.getPath() + "/note.dtd";
+
+		//@formatter:off
+		String dtdContents =
+		"<!ELEMENT note (to,from,heading,body)>\n" +
+		"<!ELEMENT to (#PCDATA)>\n" +
+		"<!ELEMENT from (#PCDATA)>\n" +
+		"<!ELEMENT heading (#PCDATA)>\n" +
+		"<!ELEMENT body (#PCDATA)>";
+	
+		String xmlContents = 
+		"<?xml version=\"1.0\"?>\n" +
+		"<!DOCTYPE note SYSTEM \"note.dtd\">\n" +
+		"<note>\n" +
+		"  <to>Tove</to>\n" +
+		"  <from>Jani</from>\n" +
+		"  <heading>Reminder</heading>\n" +
+		"  <body>Don\'t forget me this weekend!</body>\n" +
+		"</note>";
+		//@formatter:on
+
+		
+		TextDocumentItem xmlTextDocument = getXMLTextDocumentItem("test.xml", xmlContents);
+		createFile(dtdPath, dtdContents);
+		File testDtd = new File(dtdPath);
+
+		clientOpenFile(languageServer, xmlTextDocument);
+	
+		Thread.sleep(threadSleepMs);
+
+		Assert.assertEquals(1, actualDiagnostics.size());
+		Assert.assertEquals(0, actualDiagnostics.get(0).getDiagnostics().size());
+
+		editFile(testDtd, 2, "");
+		didChangedWatchedFiles(languageServer, testDtd);
+
+		Thread.sleep(threadSleepMs);
+
+		Assert.assertEquals(2, actualDiagnostics.size());
+		Assert.assertEquals("MSG_ELEMENT_NOT_DECLARED", actualDiagnostics.get(1).getDiagnostics().get(0).getCode());
+	}
+
+	@Test
+	public void externalXSDTest() throws InterruptedException, IOException {
+		String xsdPath = tempDirUri.getPath() + "/sequence.xsd";
+
+		//@formatter:off
+		String xsdContents =
+		"<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n" +
+		"<xs:schema\n" +
+		"    xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n" +
+		"    elementFormDefault=\"qualified\">\n" +
+		"  <xs:element name=\"root\">\n" +
+		"    <xs:complexType>\n" +
+		"      <xs:sequence>\n" +
+		"        <xs:element name=\"tag\"/>\n" +
+		"        <xs:element\n" +
+		"            name=\"optional\"\n" +
+		"            minOccurs=\"0\"\n" +
+		"            maxOccurs=\"3\"/>\n" +
+		"      </xs:sequence>\n" +
+		"    </xs:complexType>\n" +
+		"  </xs:element>\n" +
+		"</xs:schema>";
+	
+		String xmlContents = 
+		"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n" +
+		"<root xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"sequence.xsd\">\n" +
+		"  <tag></tag>\n" +
+		"  <optional></optional>\n" +
+		"  <optional></optional>\n" +
+		"  <optional></optional>\n" +
+		"</root>";
+		//@formatter:on
+
+		TextDocumentItem xmlTextDocument = getXMLTextDocumentItem("test.xml", xmlContents);
+		createFile(xsdPath, xsdContents);
+		File testXsd = new File(xsdPath);
+
+		clientOpenFile(languageServer, xmlTextDocument);
+	
+		Thread.sleep(threadSleepMs);
+
+		Assert.assertEquals(1, actualDiagnostics.size());
+		Assert.assertEquals(0, actualDiagnostics.get(0).getDiagnostics().size());
+
+		editFile(testXsd, 12, "            maxOccurs=\"2\"/>");
+		didChangedWatchedFiles(languageServer, testXsd);
+
+		Thread.sleep(threadSleepMs);
+
+		Assert.assertEquals(2, actualDiagnostics.size());
+		Assert.assertEquals("cvc-complex-type.2.4.f", actualDiagnostics.get(1).getDiagnostics().get(0).getCode());
+	}
+
+	private static XMLLanguageServer createServer(List<PublishDiagnosticsParams> actualDiagnostics) {
+
+		XMLLanguageServer languageServer = new XMLLanguageServer();
+		LanguageClient client = new LanguageClient() {
+
+			@Override
+			public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams requestParams) {
+				return null;
+			}
+
+			@Override
+			public void showMessage(MessageParams messageParams) {
+
+			}
+
+			@Override
+			public void publishDiagnostics(PublishDiagnosticsParams diagnostics) {
+				actualDiagnostics.add(diagnostics);
+			}
+
+			@Override
+			public void logMessage(MessageParams message) {
+
+			}
+
+			@Override
+			public void telemetryEvent(Object object) {
+
+			}
+		};
+		languageServer.setClient(client);
+		return languageServer;
+	}
+
+	private void createFile(String path, String contents) throws IOException {
+		Files.asCharSink(new File(path), Charsets.UTF_8).write(contents);
+	}
+
+	private TextDocumentItem getXMLTextDocumentItem(String filename, String xmlContents) {
+		String languageId = "xml";
+		int version = 1;
+		return new TextDocumentItem(tempDirUri.toString() + "/" + filename, languageId, version, xmlContents);
+	}
+
+	private void clientOpenFile(XMLLanguageServer languageServer, TextDocumentItem textDocumentItem) {
+		DidOpenTextDocumentParams params = new DidOpenTextDocumentParams(textDocumentItem);
+		languageServer.getTextDocumentService().didOpen(params);
+	}
+
+	private void editFile(File file, int lineNumber, String newContent) throws IOException {
+		List<String> lines = java.nio.file.Files.readAllLines(file.toPath());
+		lines.set(lineNumber - 1, newContent);
+		java.nio.file.Files.write(file.toPath(), lines);
+	}
+
+	private void didChangedWatchedFiles(XMLLanguageServer ls, File file) {
+		List<FileEvent> changes = new ArrayList<>();
+		changes.add(new FileEvent(file.toURI().toString(), FileChangeType.Changed));
+		DidChangeWatchedFilesParams params = new DidChangeWatchedFilesParams(changes);
+		ls.getWorkspaceService().didChangeWatchedFiles(params);
+	}
+}

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/settings/capabilities/XMLCapabilitiesTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/settings/capabilities/XMLCapabilitiesTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.CodeActionCapabilities;
 import org.eclipse.lsp4j.CompletionCapabilities;
+import org.eclipse.lsp4j.DidChangeWatchedFilesCapabilities;
 import org.eclipse.lsp4j.DocumentHighlightCapabilities;
 import org.eclipse.lsp4j.DocumentLinkCapabilities;
 import org.eclipse.lsp4j.DocumentSymbolCapabilities;
@@ -40,6 +41,7 @@ import org.eclipse.lsp4j.RenameCapabilities;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+import org.eclipse.lsp4j.WorkspaceClientCapabilities;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4xml.XMLTextDocumentService;
 import org.junit.Before;
@@ -54,6 +56,7 @@ public class XMLCapabilitiesTest {
 	private XMLCapabilityManager manager;
 	private ClientCapabilities clientCapabilities;
 	private TextDocumentClientCapabilities textDocument;
+	private WorkspaceClientCapabilities workspace;
 	private XMLTextDocumentService textDocumentService;
 	private Set<String> capabilityIDs;
 
@@ -64,6 +67,7 @@ public class XMLCapabilitiesTest {
 		textDocumentService.getSharedSettings().formattingSettings.setEnabled(true);
 
 		textDocument = new TextDocumentClientCapabilities();
+		workspace = new WorkspaceClientCapabilities();
 		manager = new XMLCapabilityManager(languageClient, textDocumentService);
 		clientCapabilities = new ClientCapabilities();
 		capabilityIDs = null;
@@ -75,7 +79,7 @@ public class XMLCapabilitiesTest {
 		setAllCapabilities(true);
 		setAndInitializeCapabilities();
 
-		assertEquals(10, capabilityIDs.size());
+		assertEquals(11, capabilityIDs.size());
 
 		ServerCapabilities serverCapabilities = ServerCapabilitiesInitializer
 				.getNonDynamicServerCapabilities(manager.getClientCapabilities(), false);
@@ -121,6 +125,7 @@ public class XMLCapabilitiesTest {
 		completion.setDynamicRegistration(true);
 		textDocument.setCompletion(completion);
 		textDocument.setDocumentSymbol(new DocumentSymbolCapabilities(true));
+		workspace.setDidChangeWatchedFiles(new DidChangeWatchedFilesCapabilities(true));
 
 		// Non dynamic capabilities
 		textDocument.setHover(new HoverCapabilities(false));
@@ -134,7 +139,7 @@ public class XMLCapabilitiesTest {
 
 		setAndInitializeCapabilities();
 
-		assertEquals(4, capabilityIDs.size());
+		assertEquals(5, capabilityIDs.size());
 		assertEquals(true, capabilityIDs.contains(FORMATTING_ID));
 		assertEquals(true, capabilityIDs.contains(FORMATTING_RANGE_ID));
 		assertEquals(true, capabilityIDs.contains(COMPLETION_ID));
@@ -207,10 +212,12 @@ public class XMLCapabilitiesTest {
 		textDocument.setFoldingRange(folding);
 		textDocument.setDocumentLink(new DocumentLinkCapabilities(areAllDynamic));
 		textDocument.setCodeAction(new CodeActionCapabilities(areAllDynamic));
+		workspace.setDidChangeWatchedFiles(new DidChangeWatchedFilesCapabilities(areAllDynamic));
 	}
 
 	private void setAndInitializeCapabilities() {
 		clientCapabilities.setTextDocument(textDocument);
+		clientCapabilities.setWorkspace(workspace);
 		manager.setClientCapabilities(clientCapabilities, null);
 		manager.initializeCapabilities();
 		capabilityIDs = manager.getRegisteredCapabilities();


### PR DESCRIPTION
Signed-off-by: David Kwon <dakwon@redhat.com>

Fixes [vscode-xml #132](https://github.com/redhat-developer/vscode-xml/issues/132).

This PR was tested with this `xml` document:
```
<?xml version="1.0" encoding="UTF-8" ?>
<root
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:noNamespaceSchemaLocation="sequence.xsd">
  <tag></tag>
  <optional></optional>
  <optional></optional>
  <optional></optional>
</root>
```
With this `xsd` schema:
```
<?xml version="1.0" encoding="utf-8" ?>
<xs:schema
    xmlns:xs="http://www.w3.org/2001/XMLSchema"
    elementFormDefault="qualified">
  <xs:element name="root">
    <xs:complexType>
      <xs:sequence>
        <xs:element name="tag"/>
        <xs:element
            name="optional"
            minOccurs="0"
            maxOccurs="2"/>
      </xs:sequence>
    </xs:complexType>
  </xs:element>
</xs:schema>
``` 
In the `xsd` file, I simply change the `maxOccurs` value from `2` to `3` and back to `2` in a separate editor to test this fix.

This PR will register all `xsd` files as watched files, therefore when the `xsd` files are saved externally, the client would send the `didChangeWatchedFiles`  notification. The server will check through every open xml document and validate if it is bound to the recently saved `xsd` file.

[This](https://github.com/xorye/lsp4xml/blob/f71bade25c1a02d115937bcab3c1a35e6a39c377/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/ContentModelPlugin.java#L59) check was needed because `document` is null if the document representing `documentURI` is not opened on the client side. In our case, `document` is null when an `xsd` that is not currently open in the client, has been modified and saved externally.

Note that this PR works whether or not the `xsd` file is currently open in the client. I have only written the unit test for the unopened case. I am more than willing to write one for the opened case if desired.

For the unit test, I created [this](https://github.com/xorye/lsp4xml/blob/f71bade25c1a02d115937bcab3c1a35e6a39c377/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLExternalTest.java) new file. One thing I am not sure about are the two sleep calls [here](https://github.com/xorye/lsp4xml/blob/f71bade25c1a02d115937bcab3c1a35e6a39c377/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLExternalTest.java#L132-L140). I added them because it seems like validation for the xml file is being done in a separate thread, and I wanted to wait until the validation was over, so I could read the resulting diagnostics/errors.

Validation for the `xml` document takes place when I call `didOpen()` with the xml document [here](https://github.com/xorye/lsp4xml/blob/f71bade25c1a02d115937bcab3c1a35e6a39c377/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLExternalTest.java#L204) which returns `void`.

I did not test this on Windows yet, however a fix for Windows overlaps with #506 .