### PR TITLE
Fix NPE with XSD highlight for attribute without value

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDHighlightingParticipant.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDHighlightingParticipant.java
@@ -40,9 +40,9 @@ public class XSDHighlightingParticipant implements IHighlightingParticipant {
 		if (!DOMUtils.isXSD(document)) {
 			return;
 		}
-		// Highlight works ony when attribute is selected (orign or target attribute)
+		// Highlight works only when attribute is selected (origin or target attribute)
 		DOMAttr attr = node.findAttrAt(offset);
-		if (attr == null) {
+		if (attr == null || attr.getNodeAttrValue() == null) {
 			return;
 		}
 		// Try to get the binding from the origin attribute

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDHighlightingExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDHighlightingExtensionsTest.java
@@ -136,4 +136,17 @@ public class XSDHighlightingExtensionsTest {
 				"</xs:schema>";
 		testHighlightsFor(xml, hl(r(15, 21, 15, 35), Write), hl(r(5, 22, 5, 39), Read));
 	}
+
+	@Test
+	public void noHighlightOnRefWithoutValue() throws BadLocationException {
+		// highlighting on xs:simpleType/@name
+		String xml = "<?xml version=\"1.0\" ?>\r\n" + //
+				"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n" + //
+				"\r\n" + //
+				"	<xs:element name=\"resources\">\r\n" + //
+				"		<xs:complexType>\r\n" + //
+				"			<xs:sequence>\r\n" + //
+				"				<xs:element re|f"; //
+		testHighlightsFor(xml);
+	}
 }


### PR DESCRIPTION
Fix NPE with XSD highlight for attribute without value

Take this XML Schema:

```xml
<?xml version="1.0" ?>
<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">

	<xs:element name="resources">
		<xs:complexType>
			<xs:sequence>
				<xs:element ref
```
and set cursor in ref (without value), NPE will occurs with master

Signed-off-by: azerr <azerr@redhat.com>