### PR TITLE
Fix error range for src-import.1.2, add code actions

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/codeactions/src_import_1_2CodeAction.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/codeactions/src_import_1_2CodeAction.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.lsp4xml.extensions.contentmodel.participants.codeactions;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4xml.commons.BadLocationException;
+import org.eclipse.lsp4xml.commons.CodeActionFactory;
+import org.eclipse.lsp4xml.dom.DOMDocument;
+import org.eclipse.lsp4xml.dom.DOMElement;
+import org.eclipse.lsp4xml.dom.DOMNode;
+import org.eclipse.lsp4xml.services.extensions.ICodeActionParticipant;
+import org.eclipse.lsp4xml.services.extensions.IComponentProvider;
+import org.eclipse.lsp4xml.settings.XMLFormattingOptions;
+import org.eclipse.lsp4xml.utils.XMLPositionUtility;
+
+/**
+ * Code action to fix cvc-attribute-3 error.
+ *
+ */
+public class src_import_1_2CodeAction implements ICodeActionParticipant {
+
+	@Override
+	public void doCodeAction(Diagnostic diagnostic, Range range, DOMDocument document, List<CodeAction> codeActions,
+			XMLFormattingOptions formattingSettings, IComponentProvider componentProvider) {
+
+		try {
+			String prefix = document.getDocumentElement().getPrefix();
+			CodeAction namespace = createNamespaceCodeAction(diagnostic, range, document, prefix);
+			CodeAction targetNamespace = createTargetNamespaceCodeAction(diagnostic, document, prefix);
+
+			if (namespace != null) {
+				codeActions.add(namespace);
+			}
+
+			if (targetNamespace != null) {
+				codeActions.add(targetNamespace);
+			}
+
+		} catch (BadLocationException e) {
+			// Do nothing
+		}
+	}
+
+	private CodeAction createNamespaceCodeAction(Diagnostic diagnostic, Range range, DOMDocument document, String prefix) throws BadLocationException {
+		int offset = document.offsetAt(range.getStart());
+		DOMNode node = document.findNodeAt(offset);
+
+		if (node == null || !node.isElement()) {
+			return null;
+		}
+		
+		String message;
+		if (prefix != null) {
+			message = "Insert 'namespace' attribute in '" + prefix + ":import' element";
+		} else {
+			message = "Insert 'namespace' attribute in 'import' element";
+		}
+
+		return CodeActionFactory.insert(message, range.getEnd(), " namespace=\"\"", document.getTextDocument(), diagnostic);
+	}
+
+	private CodeAction createTargetNamespaceCodeAction(Diagnostic diagnostic, DOMDocument document, String prefix) throws BadLocationException {
+		DOMElement root = document.getDocumentElement();
+
+		if (!root.getTagName().contains("schema")) {
+			return null;
+		}
+		String message;
+		if (prefix != null) {
+			message = "Insert 'targetNamespace' attribute in '" + prefix + ":schema' element";
+		} else {
+			message = "Insert 'targetNamespace' attribute in 'schema' element";
+		}
+		return CodeActionFactory.insert(message, document.positionAt(root.getStartTagCloseOffset()), " targetNamespace=\"\"", document.getTextDocument(), diagnostic);
+	}
+
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDErrorCode.java
@@ -19,6 +19,7 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4xml.dom.DOMDocument;
 import org.eclipse.lsp4xml.dom.DOMNode;
 import org.eclipse.lsp4xml.extensions.contentmodel.participants.codeactions.s4s_elt_invalid_content_3CodeAction;
+import org.eclipse.lsp4xml.extensions.contentmodel.participants.codeactions.src_import_1_2CodeAction;
 import org.eclipse.lsp4xml.services.extensions.ICodeActionParticipant;
 import org.eclipse.lsp4xml.services.extensions.diagnostics.IXMLErrorCode;
 import org.eclipse.lsp4xml.utils.XMLPositionUtility;
@@ -45,6 +46,7 @@ public enum XSDErrorCode implements IXMLErrorCode {
 	s4s_elt_invalid_content_3("s4s-elt-invalid-content.3"), //
 	sch_props_correct_2("sch-props-correct.2"),
 	src_ct_1("src-ct.1"),
+	src_import_1_2("src-import.1.2"),
 	src_element_3("src-element.3"),
 	src_resolve_4_2("src-resolve.4.2"), //
 	src_resolve("src-resolve"), src_element_2_1("src-element.2.1"),
@@ -123,6 +125,7 @@ public enum XSDErrorCode implements IXMLErrorCode {
 		case s4s_elt_invalid_content_3:
 		case src_element_2_1:
 		case src_element_3:
+		case src_import_1_2:
 			return XMLPositionUtility.selectStartTag(offset, document);
 		case s4s_att_not_allowed: {
 			String attrName = (String) arguments[1];
@@ -157,5 +160,6 @@ public enum XSDErrorCode implements IXMLErrorCode {
 
 	public static void registerCodeActionParticipants(Map<String, ICodeActionParticipant> codeActions) {
 		codeActions.put(s4s_elt_invalid_content_3.getCode(), new s4s_elt_invalid_content_3CodeAction());
+		codeActions.put(src_import_1_2.getCode(), new src_import_1_2CodeAction());
 	}
 }

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDValidationExtensionsTest.java
@@ -311,6 +311,30 @@ public class XSDValidationExtensionsTest {
 		testDiagnosticsFor(xml, d(1, 3, 1, 13, XSDErrorCode.src_element_3));
 	}
 
+	@Test
+	public void src_import_1_2xs() throws BadLocationException {
+		String xml = "<?xml version=\'1.0\'?>\r\n" +
+			"<xs:schema xmlns:xs=\'http://www.w3.org/2001/XMLSchema\'>\r\n" +
+			"	<xs:import></xs:import>\r\n" +
+			"</xs:schema>";
+
+		Diagnostic d = d(2, 2, 2, 11, XSDErrorCode.src_import_1_2);
+		testDiagnosticsFor(xml, d);
+		testCodeActionsFor(xml, d, ca(d, te(2, 11, 2, 11, " namespace=\"\"")), ca(d, te(1, 54, 1, 54, " targetNamespace=\"\"")));
+	}
+
+	@Test
+	public void src_import_1_2() throws BadLocationException {
+		String xml = "<?xml version=\'1.0\'?>\r\n" +
+			"<schema xmlns=\'http://www.w3.org/2001/XMLSchema\'>\r\n" +
+			"	<import></import>\r\n" +
+			"</schema>";
+
+		Diagnostic d = d(2, 2, 2, 8, XSDErrorCode.src_import_1_2);
+		testDiagnosticsFor(xml, d);
+		testCodeActionsFor(xml, d, ca(d, te(2, 8, 2, 8, " namespace=\"\"")), ca(d, te(1, 48, 1, 48, " targetNamespace=\"\"")));
+	}
+
 	private static void testDiagnosticsFor(String xml, Diagnostic... expected) throws BadLocationException {
 		XMLAssert.testDiagnosticsFor(xml, null, null, "test.xsd", expected);
 	}


### PR DESCRIPTION
Fixes #499 

![image](https://user-images.githubusercontent.com/20326645/61330308-4ea47800-a7ed-11e9-8cab-7af2f56c0e0b.png)



The result of the first code action:
![image](https://user-images.githubusercontent.com/20326645/61329500-7397eb80-a7eb-11e9-8051-0614e41c2d64.png)

The result of the second code action:
![image](https://user-images.githubusercontent.com/20326645/61329530-86aabb80-a7eb-11e9-92a4-12668cf97cf7.png)

The code actions' message's "import" and "schema" strings are hardcoded. If a prefix does not exist,
there will be no prefix in the code actions' messages: 
![image](https://user-images.githubusercontent.com/20326645/61330334-5e23c100-a7ed-11e9-8cc2-17932242a4ee.png)

Signed-off-by: David Kwon <dakwon@redhat.com>