### PR TITLE
Fix failing test teardown on macOS

### DIFF
--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLExternalTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLExternalTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
 import com.google.common.io.MoreFiles;
+import com.google.common.io.RecursiveDeleteOption;
 
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
@@ -53,7 +54,7 @@ public class XMLExternalTest {
 
 	private int threadSleepMs = 600;
 	
-	private static String tempDirPath = "./target/temp/";
+	private static String tempDirPath = "target/temp/";
 	private static URI tempDirUri = Paths.get(tempDirPath).toAbsolutePath().toUri();
 
 	private List<PublishDiagnosticsParams> actualDiagnostics;
@@ -79,7 +80,7 @@ public class XMLExternalTest {
 	private static void deleteTempDirIfExists() throws IOException {
 		File tempDir = new File(tempDirUri);
 		if (tempDir.exists()) {
-			MoreFiles.deleteRecursively(tempDir.toPath());
+			MoreFiles.deleteRecursively(tempDir.toPath(), RecursiveDeleteOption.ALLOW_INSECURE);
 		}
 	}
 


### PR DESCRIPTION
```
[INFO] Running org.eclipse.lsp4xml.extensions.contentmodel.XMLExternalTest
[ERROR] Tests run: 3, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 2.47 s <<< FAILURE! - in org.eclipse.lsp4xml.extensions.contentmodel.XMLExternalTest
[ERROR] org.eclipse.lsp4xml.extensions.contentmodel.XMLExternalTest  Time elapsed: 1.215 s  <<< ERROR!
com.google.common.io.InsecureRecursiveDeleteException: /Users/fbricon/Dev/projects/lsp4xml/org.eclipse.lsp4xml/target/temp: unable to guarantee security of recursive delete
	at org.eclipse.lsp4xml.extensions.contentmodel.XMLExternalTest.deleteTempDirIfExists(XMLExternalTest.java:82)
	at org.eclipse.lsp4xml.extensions.contentmodel.XMLExternalTest.tearDown(XMLExternalTest.java:70)
```