### PR TITLE
Fix error range for EntityNotDeclared

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/DTDErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/DTDErrorCode.java
@@ -17,6 +17,7 @@ import org.apache.xerces.xni.XMLLocator;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4xml.commons.BadLocationException;
+import org.eclipse.lsp4xml.commons.TextDocument;
 import org.eclipse.lsp4xml.dom.DOMDocument;
 import org.eclipse.lsp4xml.dom.DOMElement;
 import org.eclipse.lsp4xml.extensions.contentmodel.participants.codeactions.ElementDeclUnterminatedCodeAction;
@@ -36,6 +37,7 @@ public enum DTDErrorCode implements IXMLErrorCode {
 	AttTypeRequiredInAttDef,
 	ElementDeclUnterminated,
 	EntityDeclUnterminated,
+	EntityNotDeclared,
 	ExternalIDorPublicIDRequired,
 	IDInvalidWithNamespaces,
 	IDREFInvalidWithNamespaces,
@@ -154,7 +156,23 @@ public enum DTDErrorCode implements IXMLErrorCode {
 		case PEReferenceWithinMarkup: {
 			return XMLPositionUtility.getLastValidDTDDeclParameter(offset, document, true);
 		}
-		
+		case EntityNotDeclared: {
+			try {
+				Position position = document.positionAt(offset);
+				int line = position.getLine();
+				String text = document.lineText(line);
+				String name = (String) arguments[0];
+				String subString = "&" + name + ";";
+				int start = text.indexOf(subString);
+				int end = start + subString.length();
+				Position startPosition = new Position(line, start);
+				Position endPosition = new Position(line, end);
+				return new Range(startPosition, endPosition);
+			} catch (BadLocationException e) {
+
+			}
+
+		}
 		case QuoteRequiredInPublicID:
 		case QuoteRequiredInSystemID:
 		case OpenQuoteMissingInDecl:

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/DTDDiagnosticsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/DTDDiagnosticsTest.java
@@ -289,6 +289,19 @@ public class DTDDiagnosticsTest {
 	}
 
 	@Test
+	public void EntityNotDeclared() throws Exception {
+		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+				"<!DOCTYPE article [\r\n" +
+				"	<!ELEMENT article (#PCDATA)>\r\n" +
+				"]>\r\n" +
+				"<article>\r\n" +
+				"	&nbsp;\r\n" +
+				"</article>";
+
+		XMLAssert.testDiagnosticsFor(xml, d(5, 1, 7, DTDErrorCode.EntityNotDeclared));
+	}
+
+	@Test
 	public void ElementDeclUnterminated() throws Exception {
 		String xml = "<?xml version = \"1.0\"?>\r\n" + //
 				"<!DOCTYPE Person [\r\n" + //


### PR DESCRIPTION
Fixes the error range mentioned in #518 

![image](https://user-images.githubusercontent.com/20326645/61641276-d7e40080-ac6c-11e9-9436-f39a690fc36c.png)

I am using the name of the undeclared entity, (in this case, "nbsp"), looking for the substring "&nbsp" in the line provided by xerces to determine the error range.

Signed-off-by: David Kwon <dakwon@redhat.com>