### PR TITLE
Fix error range for `cvc-datatype-valid-1-2-1`

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/XMLSchemaErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/XMLSchemaErrorCode.java
@@ -20,6 +20,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4xml.commons.BadLocationException;
 import org.eclipse.lsp4xml.dom.DOMDocument;
+import org.eclipse.lsp4xml.dom.DOMElement;
 import org.eclipse.lsp4xml.dom.DOMNode;
 import org.eclipse.lsp4xml.dom.NoNamespaceSchemaLocation;
 import org.eclipse.lsp4xml.dom.SchemaLocation;
@@ -32,6 +33,7 @@ import org.eclipse.lsp4xml.extensions.contentmodel.participants.codeactions.cvc_
 import org.eclipse.lsp4xml.extensions.contentmodel.participants.codeactions.cvc_type_3_1_1CodeAction;
 import org.eclipse.lsp4xml.services.extensions.ICodeActionParticipant;
 import org.eclipse.lsp4xml.services.extensions.diagnostics.IXMLErrorCode;
+import org.eclipse.lsp4xml.utils.DOMUtils;
 import org.eclipse.lsp4xml.utils.XMLPositionUtility;
 
 /**
@@ -192,11 +194,26 @@ public enum XMLSchemaErrorCode implements IXMLErrorCode {
 		case cvc_type_3_1_1:
 			return XMLPositionUtility.selectAllAttributes(offset, document);
 		case cvc_complex_type_2_1:
-		case cvc_type_3_1_3:
 		case cvc_elt_3_2_1:
 			return XMLPositionUtility.selectContent(offset, document);
+		case cvc_type_3_1_3:
+		case cvc_datatype_valid_1_2_1: {
+			String attrValue = getString(arguments[0]);
+			Range range = XMLPositionUtility.selectAttributeValueFromGivenValue(attrValue, offset, document);
+			
+			if (range != null) {
+				return range;
+			}
+
+			DOMElement element = (DOMElement) document.findNodeAt(offset);
+
+			if (DOMUtils.containsTextOnly(element)) {
+				return XMLPositionUtility.selectTextTrimmed(offset, document);
+			} else {
+				return XMLPositionUtility.selectFirstChild(offset, document);
+			}
+		}
 		case cvc_enumeration_valid:
-		case cvc_datatype_valid_1_2_1:
 		case cvc_maxlength_valid:
 		case cvc_minlength_valid:
 		case cvc_maxExclusive_valid:

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLRename.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/XMLRename.java
@@ -111,7 +111,7 @@ public class XMLRename {
 	}
 
 	/**
-     * Returns <code>DOMElement</code> associated with 
+	 * Returns <code>DOMElement</code> associated with 
 	 * <code>node</code>
 	 * 
 	 * @param node node representing an element or attribute

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/DOMUtils.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/DOMUtils.java
@@ -89,4 +89,12 @@ public class DOMUtils {
 		return uri != null
 				&& (uri.endsWith(DTD_EXTENSION) || uri.endsWith(ENT_EXTENSION) || uri.endsWith(MOD_EXTENSION));
 	}
+
+	/**
+	 * Returns true if element contains only DOMText and false otherwise.
+	 * @return true if element contains only DOMText and false otherwise.
+	 */
+	public static boolean containsTextOnly(DOMElement element) {
+		return element.getChildNodes().getLength() == 1 && element.getFirstChild().isText();
+	}
 }

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/StringUtils.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/utils/StringUtils.java
@@ -263,6 +263,48 @@ public class StringUtils {
 		return -1;
 	}
 
+	/**
+	 * Returns the number of consecutive whitespace characters in front
+	 * of text 
+	 * @param text String of interest
+	 * @return the number of consecutive whitespace characters in front
+	 * of text 
+	 */
+	public static int getFrontWhitespaceLength(String text) {
+
+		if (StringUtils.isWhitespace(text)) {
+			return text.length();
+		}
+
+		int i = 0;
+		while (Character.isWhitespace(text.charAt(i))) {
+			i++;
+		}
+
+		return i;
+	}
+
+	/**
+	 * Returns the number of consecutive whitespace characters from
+	 * the end of text
+	 * @param text String of interest
+	 * @return the number of consecutive whitespace characters from
+	 * the end of text
+	 */
+	public static int getTrailingWhitespaceLength(String text) {
+		
+		if (StringUtils.isWhitespace(text)) {
+			return text.length();
+		}
+
+		int i = text.length() - 1;
+		while (Character.isWhitespace(text.charAt(i))) {
+			i--;
+		}
+
+		return text.length() - i - 1;
+	}
+
 	public static String cleanPathForWindows(String pathString) {
 		if (pathString.startsWith("/")) {
 			if (pathString.length() > 3) {

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSchemaDiagnosticsTest.java
@@ -279,6 +279,47 @@ public class XMLSchemaDiagnosticsTest {
 	}
 
 	@Test
+	public void cvc_datatype_valid_1_2_1_TextOnlyWithWhitespace() throws Exception {
+		String xml = "<a xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \r\n" +
+				"    xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/integerElement.xsd\">\r\n" +
+				"\r\n" +
+				"    TEXT\r\n" +
+				"\r\n" +
+				"</a>";
+		testDiagnosticsFor(xml, d(3, 4, 3, 8, XMLSchemaErrorCode.cvc_datatype_valid_1_2_1),
+				d(3, 4, 3, 8, XMLSchemaErrorCode.cvc_type_3_1_3));
+	}
+
+	@Test
+	public void cvc_datatype_valid_1_2_1_OneElement() throws Exception {
+		String xml = "<a xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \r\n" +
+				"    xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/integerElement.xsd\">\r\n" +
+				"\r\n" +
+				"    <b></b>\r\n" +
+				"\r\n" +
+				"</a>";
+
+		testDiagnosticsFor(xml, d(0, 1, 0, 2 , XMLSchemaErrorCode.cvc_type_3_1_2),
+				d(3, 4, 3, 11, XMLSchemaErrorCode.cvc_datatype_valid_1_2_1),
+				d(3, 4, 3, 11, XMLSchemaErrorCode.cvc_type_3_1_3));
+	}
+
+	@Test
+	public void cvc_datatype_valid_1_2_1_TwoElements() throws Exception {
+		String xml = "<a xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" \r\n" +
+				"    xsi:noNamespaceSchemaLocation=\"src/test/resources/xsd/integerElement.xsd\">\r\n" +
+				"\r\n" +
+				"    <b></b>\r\n" +
+				"    <c></c>\r\n" +
+				"\r\n" +
+				"</a>";
+
+		testDiagnosticsFor(xml, d(0, 1, 0, 2 , XMLSchemaErrorCode.cvc_type_3_1_2),
+				d(3, 4, 3, 11, XMLSchemaErrorCode.cvc_datatype_valid_1_2_1),
+				d(3, 4, 3, 11, XMLSchemaErrorCode.cvc_type_3_1_3));
+	}
+
+	@Test
 	public void cvc_maxLength_validOnAttribute() throws Exception {
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" + //
 				"<team\r\n" + //

--- a/org.eclipse.lsp4xml/src/test/resources/xsd/integerElement.xsd
+++ b/org.eclipse.lsp4xml/src/test/resources/xsd/integerElement.xsd
@@ -1,0 +1,4 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="a" type="xs:integer">
+  </xs:element>
+</xs:schema>


### PR DESCRIPTION
Fixes #323 

Xerces gives us the location of the element `<a>`. This PR looks at the contents of `<a>` to determine the error range.

![image](https://user-images.githubusercontent.com/20326645/61739457-713d1080-ad5a-11e9-89f6-ab9c8ce69f60.png)
![image](https://user-images.githubusercontent.com/20326645/61739498-87e36780-ad5a-11e9-8f38-391933508644.png)

If there are no non-whitespace characters in the element's contents, the error range looks like this:
![image](https://user-images.githubusercontent.com/20326645/61739659-dee93c80-ad5a-11e9-9cd6-c156e6e7f900.png)


Signed-off-by: David Kwon <dakwon@redhat.com>