### PR TITLE
Add ability to rename complexType/@name inside XML schema

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/DTDErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/DTDErrorCode.java
@@ -19,7 +19,6 @@ import org.apache.xerces.xni.XMLLocator;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4xml.commons.BadLocationException;
-import org.eclipse.lsp4xml.commons.TextDocument;
 import org.eclipse.lsp4xml.dom.DOMDocument;
 import org.eclipse.lsp4xml.dom.DOMElement;
 import org.eclipse.lsp4xml.extensions.contentmodel.participants.codeactions.ElementDeclUnterminatedCodeAction;

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/codeactions/src_import_1_2CodeAction.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/codeactions/src_import_1_2CodeAction.java
@@ -23,7 +23,6 @@ import org.eclipse.lsp4xml.dom.DOMNode;
 import org.eclipse.lsp4xml.services.extensions.ICodeActionParticipant;
 import org.eclipse.lsp4xml.services.extensions.IComponentProvider;
 import org.eclipse.lsp4xml.settings.XMLFormattingOptions;
-import org.eclipse.lsp4xml.utils.XMLPositionUtility;
 
 /**
  * Code action to fix cvc-attribute-3 error.

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/XSDPlugin.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/XSDPlugin.java
@@ -20,11 +20,13 @@ import org.eclipse.lsp4xml.extensions.xsd.participants.XSDCompletionParticipant;
 import org.eclipse.lsp4xml.extensions.xsd.participants.XSDDefinitionParticipant;
 import org.eclipse.lsp4xml.extensions.xsd.participants.XSDHighlightingParticipant;
 import org.eclipse.lsp4xml.extensions.xsd.participants.XSDReferenceParticipant;
+import org.eclipse.lsp4xml.extensions.xsd.participants.XSDRenameParticipant;
 import org.eclipse.lsp4xml.extensions.xsd.participants.diagnostics.XSDDiagnosticsParticipant;
 import org.eclipse.lsp4xml.services.extensions.ICompletionParticipant;
 import org.eclipse.lsp4xml.services.extensions.IDefinitionParticipant;
 import org.eclipse.lsp4xml.services.extensions.IHighlightingParticipant;
 import org.eclipse.lsp4xml.services.extensions.IReferenceParticipant;
+import org.eclipse.lsp4xml.services.extensions.IRenameParticipant;
 import org.eclipse.lsp4xml.services.extensions.IXMLExtension;
 import org.eclipse.lsp4xml.services.extensions.XMLExtensionsRegistry;
 import org.eclipse.lsp4xml.services.extensions.codelens.ICodeLensParticipant;
@@ -46,6 +48,7 @@ public class XSDPlugin implements IXMLExtension {
 	private final IReferenceParticipant referenceParticipant;
 	private final ICodeLensParticipant codeLensParticipant;
 	private final IHighlightingParticipant highlightingParticipant;
+	private final IRenameParticipant renameParticipant;
 	private XSDURIResolverExtension uiResolver;
 
 	private ContentModelManager modelManager;
@@ -57,6 +60,7 @@ public class XSDPlugin implements IXMLExtension {
 		referenceParticipant = new XSDReferenceParticipant();
 		codeLensParticipant = new XSDCodeLensParticipant();
 		highlightingParticipant = new XSDHighlightingParticipant();
+		renameParticipant = new XSDRenameParticipant();
 	}
 
 	@Override
@@ -87,6 +91,7 @@ public class XSDPlugin implements IXMLExtension {
 		registry.registerReferenceParticipant(referenceParticipant);
 		registry.registerCodeLensParticipant(codeLensParticipant);
 		registry.registerHighlightingParticipant(highlightingParticipant);
+		registry.registerRenameParticipant(renameParticipant);
 	}
 
 	@Override
@@ -98,5 +103,6 @@ public class XSDPlugin implements IXMLExtension {
 		registry.unregisterReferenceParticipant(referenceParticipant);
 		registry.unregisterCodeLensParticipant(codeLensParticipant);
 		registry.unregisterHighlightingParticipant(highlightingParticipant);
+		registry.unregisterRenameParticipant(renameParticipant);
 	}
 }

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDRenameParticipant.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/xsd/participants/XSDRenameParticipant.java
@@ -1,0 +1,146 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.extensions.xsd.participants;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4xml.commons.BadLocationException;
+import org.eclipse.lsp4xml.dom.DOMAttr;
+import org.eclipse.lsp4xml.dom.DOMDocument;
+import org.eclipse.lsp4xml.dom.DOMElement;
+import org.eclipse.lsp4xml.dom.DOMNode;
+import org.eclipse.lsp4xml.extensions.xsd.utils.XSDUtils;
+import org.eclipse.lsp4xml.services.extensions.IRenameParticipant;
+import org.eclipse.lsp4xml.services.extensions.IRenameRequest;
+import org.eclipse.lsp4xml.utils.DOMUtils;
+import org.eclipse.lsp4xml.utils.XMLPositionUtility;
+
+/**
+ * XSD rename
+ * 
+ */
+public class XSDRenameParticipant implements IRenameParticipant {
+
+	@Override
+	public void doRename(IRenameRequest request, List<TextEdit> locations) {
+		DOMDocument xmlDocument = request.getXMLDocument();
+
+		if (!DOMUtils.isXSD(xmlDocument)) {
+			return;
+		}
+		for (TextEdit textEdit: getRenameTextEdits(request)) {
+			locations.add(textEdit);
+		}
+
+	}
+
+	private List<TextEdit> getRenameTextEdits(IRenameRequest request) {
+		DOMDocument document = request.getXMLDocument();
+		DOMNode node = request.getNode();
+
+		if (!node.isAttribute()) {
+			return Collections.emptyList();
+		}
+
+		DOMAttr attr = (DOMAttr) node;
+		DOMElement ownerElement = attr.getOwnerElement();
+
+		if (ownerElement == null) {
+			return Collections.emptyList();
+		}
+
+		String newText = request.getNewText();
+
+		if (XSDUtils.isXSComplexType(ownerElement) || XSDUtils.isXSSimpleType(ownerElement)) {
+			
+			if (attr.getName().equals("name")) {
+				List<Location> locations = getReferenceLocations(ownerElement);
+				return renameAttributeValueTextEdits(document, attr, newText, locations);
+			}
+		}
+
+		return Collections.emptyList();
+	}
+
+	private List<Location> getReferenceLocations(DOMNode node) {
+
+		List<Location> locations = new ArrayList<>();
+
+		XSDUtils.searchXSOriginAttributes(node,
+		(origin, target) -> locations.add(XMLPositionUtility.createLocation(origin.getNodeAttrValue())),
+		null);
+
+		return locations;
+	}
+
+	private List<TextEdit> renameAttributeValueTextEdits(DOMDocument document, DOMAttr attribute, String newText, List<Location> locations) {
+		DOMNode attrValue = attribute.getNodeAttrValue();
+		List<TextEdit> textEdits = new ArrayList<>();
+
+		int valueStart = attrValue.getStart();
+		int valueEnd = attrValue.getEnd();
+		Range range = XMLPositionUtility.createRange(valueStart, valueEnd, document);
+
+		// make range not cover " on both ends
+		reduceRangeFromBothEnds(range, 1);
+
+		textEdits.add(new TextEdit(range, newText));
+
+		for (Location location: locations) {
+			Range textEditRange = location.getRange();
+			reduceRangeFromBothEnds(textEditRange, 1);
+
+			String oldAttrValue;
+			try {
+				oldAttrValue = getAttrTextValueFromPosition(document, location.getRange().getStart());
+			} catch (BadLocationException e1) {
+				return Collections.emptyList();
+			}
+			
+			int colonIndex = oldAttrValue.indexOf(":");
+			
+			if (colonIndex > 0) {
+				increaseStartRange(textEditRange, colonIndex + 1);
+			}
+
+			TextEdit textEdit = new TextEdit(textEditRange, newText);
+			textEdits.add(textEdit);
+		}
+
+		return textEdits;
+	}
+
+	private void reduceRangeFromBothEnds(Range range, int reduce) {
+		increaseStartRange(range, reduce);
+		decreaseEndRange(range, reduce);
+	}
+
+	private void increaseStartRange(Range range, int increase) {
+		int startCharacter = range.getStart().getCharacter();
+		range.getStart().setCharacter(startCharacter + increase);
+	}
+
+	private void decreaseEndRange(Range range, int decrease) {
+		int endCharacter = range.getEnd().getCharacter();
+		range.getEnd().setCharacter(endCharacter - decrease);
+	}
+
+	private String getAttrTextValueFromPosition(DOMDocument document, Position position) throws BadLocationException {
+		int offset = document.offsetAt(position);
+		return document.findAttrAt(offset).getValue();
+	}
+	
+} 

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/RenameRequest.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/RenameRequest.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.services;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4xml.commons.BadLocationException;
+import org.eclipse.lsp4xml.dom.DOMDocument;
+import org.eclipse.lsp4xml.services.extensions.IRenameRequest;
+import org.eclipse.lsp4xml.services.extensions.XMLExtensionsRegistry;
+
+class RenameRequest extends AbstractPositionRequest implements IRenameRequest {
+
+	private final String newText;
+	
+	public RenameRequest(DOMDocument document, Position position, String newText, XMLExtensionsRegistry extensionsRegistry) throws BadLocationException {
+		super(document, position, extensionsRegistry);
+		this.newText = newText;
+	}
+
+	public String getNewText() {
+		return newText;
+	}
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/IRenameParticipant.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/IRenameParticipant.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+
+package org.eclipse.lsp4xml.services.extensions;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.TextEdit;
+
+/**
+ * Rename participant API.
+ *
+ */
+public interface IRenameParticipant {
+
+	void doRename(IRenameRequest request, List<TextEdit> locations);
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/IRenameRequest.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/IRenameRequest.java
@@ -1,0 +1,19 @@
+
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.services.extensions;
+
+/**
+ * Definition request API.
+ *
+ */
+public interface IRenameRequest extends IPositionRequest {
+	String getNewText();
+}

--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/XMLExtensionsRegistry.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/services/extensions/XMLExtensionsRegistry.java
@@ -46,6 +46,7 @@ public class XMLExtensionsRegistry implements IComponentProvider {
 	private final List<IReferenceParticipant> referenceParticipants;
 	private final List<ICodeLensParticipant> codeLensParticipants;
 	private final List<IHighlightingParticipant> highlightingParticipants;
+	private final List<IRenameParticipant> renameParticipants;
 
 	private IXMLDocumentProvider documentProvider;
 
@@ -69,6 +70,7 @@ public class XMLExtensionsRegistry implements IComponentProvider {
 		referenceParticipants = new ArrayList<>();
 		codeLensParticipants = new ArrayList<>();
 		highlightingParticipants = new ArrayList<>();
+		renameParticipants = new ArrayList<>();
 		resolverExtensionManager = new URIResolverExtensionManager();
 		components = new HashMap<>();
 		registerComponent(resolverExtensionManager);
@@ -154,6 +156,11 @@ public class XMLExtensionsRegistry implements IComponentProvider {
 		return highlightingParticipants;
 	}
 
+	public Collection<IRenameParticipant> getRenameParticipants() {
+		initializeIfNeeded();
+		return renameParticipants;
+	}
+
 	public void initializeIfNeeded() {
 		if (initialized) {
 			return;
@@ -162,9 +169,11 @@ public class XMLExtensionsRegistry implements IComponentProvider {
 	}
 
 	private synchronized void initialize() {
+		
 		if (initialized) {
 			return;
 		}
+
 		ServiceLoader<IXMLExtension> extensions = ServiceLoader.load(IXMLExtension.class);
 		extensions.forEach(extension -> {
 			registerExtension(extension);
@@ -267,6 +276,14 @@ public class XMLExtensionsRegistry implements IComponentProvider {
 
 	public void unregisterHighlightingParticipant(IHighlightingParticipant highlightingParticipant) {
 		highlightingParticipants.add(highlightingParticipant);
+	}
+
+	public void registerRenameParticipant(IRenameParticipant renameParticipant) {
+		renameParticipants.add(renameParticipant);
+	}
+
+	public void unregisterRenameParticipant(IRenameParticipant renameParticipant) {
+		renameParticipants.add(renameParticipant);
 	}
 
 	/**

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/XMLAssert.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/XMLAssert.java
@@ -888,4 +888,24 @@ public class XMLAssert {
 					document.getText().substring(actualStartOffset, actualEndOffset).toLowerCase());
 		}
 	}
+
+	// ------------------- Rename assert
+
+	public static void assertRename(String value, String newText) throws BadLocationException {
+		assertRename(value, newText, Collections.emptyList());
+	}
+
+	public static void assertRename(String value, String newText, List<TextEdit> expectedEdits) throws BadLocationException {
+		int offset = value.indexOf("|");
+		value = value.substring(0, offset) + value.substring(offset + 1);
+
+		DOMDocument document = DOMParser.getInstance().parse(value, "test://test/test.html", null);
+
+		Position position = document.positionAt(offset);
+		
+		XMLLanguageService languageService = new XMLLanguageService();
+		WorkspaceEdit workspaceEdit = languageService.doRename(document, position, newText);
+		List<TextEdit> actualEdits = workspaceEdit.getChanges().get("test://test/test.html");
+		Assert.assertArrayEquals(expectedEdits.toArray(), actualEdits.toArray());
+	}
 }

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDRenameExtensionsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/xsd/XSDRenameExtensionsTest.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+* Copyright (c) 2019 Red Hat Inc. and others.
+* All rights reserved. This program and the accompanying materials
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v20.html
+*
+* Contributors:
+*     Red Hat Inc. - initial API and implementation
+*******************************************************************************/
+package org.eclipse.lsp4xml.extensions.xsd;
+
+import static org.eclipse.lsp4xml.XMLAssert.assertRename;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4xml.commons.BadLocationException;
+import org.junit.Test;
+
+/**
+ * XSD rename tests.
+ *
+ */
+public class XSDRenameExtensionsTest {
+
+	@Test
+	public void testRenameComplexTypeName() throws BadLocationException {
+
+		String xml = 
+			"<?xml version=\"1.1\" ?>\r\n" +
+			"<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\r\n" +
+			"\r\n" +
+			"  <xs:element name=\"employee\" type=\"personinfo\"></xs:element>\r\n" +
+			"  <xs:complexType name=\"|personinfo\"></xs:complexType>\r\n" +
+			"  <xs:complexType name=\"fullpersoninfo\">\r\n" +
+			"    <xs:complexContent>\r\n" +
+			"      <xs:extension base=\"personinfo\"></xs:extension>\r\n" +
+			"    </xs:complexContent>\r\n" +
+			"  </xs:complexType>\r\n" +
+			"</xs:schema>";
+
+		assertRename(xml, "newName", edits("newName", r(4, 24, 34), r(3, 36, 46), r(7, 26, 36))); 
+	}
+
+	@Test
+	public void testRenameSimpleTypeName() throws BadLocationException {
+
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<xsd:schema elementFormDefault=\"qualified\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"http://invoice\" xmlns:i=\"http://invoice\">\r\n" +
+			"	<xsd:simpleType name=\"paymentMe|thodType\">\r\n" +
+			"		<xsd:restriction base=\"xsd:string\">\r\n" +
+			"		</xsd:restriction>\r\n" +
+			"	</xsd:simpleType>\r\n" +
+			"</xsd:schema>";
+
+		assertRename(xml, "newName", edits("newName", r(2, 23, 40))); 
+	}
+
+	@Test
+	public void testRenameSimpleTypeNameWithPrefix() throws BadLocationException {
+
+		String xml = 
+			"<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\r\n" +
+			"<xsd:schema elementFormDefault=\"qualified\" xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\" targetNamespace=\"http://invoice\" xmlns:i=\"http://invoice\">\r\n" +
+			"	<xsd:complexType name=\"paymentType\">\r\n" +
+			"		<xsd:attribute name=\"method\" type=\"i:paymentMethodType\" use=\"required\"></xsd:attribute>\r\n" +
+			"	</xsd:complexType>\r\n" +
+			"	<xsd:simpleType name=\"paymentMetho|dType\">\r\n" +
+			"		<xsd:restriction base=\"xsd:string\">\r\n" +
+			"		</xsd:restriction>\r\n" +
+			"	</xsd:simpleType>\r\n" +
+			"</xsd:schema>";
+
+		assertRename(xml, "newName", edits("newName", r(5, 23, 40), r(3, 39, 56))); 
+	}
+
+	private static Range r(int line, int startCharacter, int endCharacter) {
+		return new Range(new Position(line, startCharacter), new Position(line, endCharacter));
+	}
+
+	private static List<TextEdit> edits(String newText, Range... ranges) {
+		return Stream.of(ranges).map(r -> new TextEdit(r, newText)).collect(Collectors.toList());
+	}
+
+}

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLRenameTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/services/XMLRenameTest.java
@@ -10,7 +10,8 @@
  */
 package org.eclipse.lsp4xml.services;
 
-import java.util.Collections;
+import static org.eclipse.lsp4xml.XMLAssert.assertRename;
+
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -18,12 +19,7 @@ import java.util.stream.Stream;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
-import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4xml.commons.BadLocationException;
-import org.eclipse.lsp4xml.dom.DOMDocument;
-import org.eclipse.lsp4xml.dom.DOMParser;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -31,13 +27,6 @@ import org.junit.Test;
  *
  */
 public class XMLRenameTest {
-
-	private XMLLanguageService languageService;
-
-	@Before
-	public void initializeLanguageService() {
-		languageService = new XMLLanguageService();
-	}
 
 	@Test
 	public void single() throws BadLocationException {
@@ -166,22 +155,7 @@ public class XMLRenameTest {
 			assertRename(xml, "BBBB"); 
 	}
 
-	private void assertRename(String value, String newText) throws BadLocationException {
-		assertRename(value, newText, Collections.emptyList());
-	}
 
-	private void assertRename(String value, String newText, List<TextEdit> expectedEdits) throws BadLocationException {
-		int offset = value.indexOf("|");
-		value = value.substring(0, offset) + value.substring(offset + 1);
-
-		DOMDocument document = DOMParser.getInstance().parse(value, "test://test/test.html", null);
-
-		Position position = document.positionAt(offset);
-
-		WorkspaceEdit workspaceEdit = languageService.doRename(document, position, newText);
-		List<TextEdit> actualEdits = workspaceEdit.getChanges().get("test://test/test.html");
-		Assert.assertArrayEquals(expectedEdits.toArray(), actualEdits.toArray());
-	}
 
 	private static Range r(int line, int startCharacter, int endCharacter) {
 		return new Range(new Position(line, startCharacter), new Position(line, endCharacter));


### PR DESCRIPTION
Fixes #454 

This PR checks if the attribute of the value to be renamed is "name", and the element is "complexType".

Currently, I'm not too sure if my code is easily extendable to different kinds of attribute value renaming, and renaming across separate files.

![rename gif](https://raw.githubusercontent.com/xorye/gifs/master/%23454/rename.gif?token=AE3CR5KHOP42CB557RY7LXK5MAACA)

Signed-off-by: David Kwon <dakwon@redhat.com>