### PR TITLE
Fix error range for RootElementTypeMustMatchDoctypedecl

### DIFF
--- a/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
+++ b/org.eclipse.lsp4xml/src/main/java/org/eclipse/lsp4xml/extensions/contentmodel/participants/XMLSyntaxErrorCode.java
@@ -46,11 +46,13 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 	EncodingDeclRequired, // https://wiki.xmldation.com/Support/Validator/EncodingDeclRequired
 	ETagRequired, // https://wiki.xmldation.com/Support/Validator/ETagRequired
 	ETagUnterminated, // https://wiki.xmldation.com/Support/Validator/ETagUnterminated
-	EqRequiredInAttribute, the_element_type_lmsg("the-element-type-lmsg"), EqRequiredInXMLDecl, IllegalQName,
+	EqRequiredInAttribute, // https://wiki.xmldation.com/Support/Validator/EqRequiredInAttribute
+	the_element_type_lmsg("the-element-type-lmsg"), EqRequiredInXMLDecl, IllegalQName,
 	InvalidCommentStart, LessthanInAttValue, MarkupEntityMismatch, MarkupNotRecognizedInContent,
 	NameRequiredInReference, OpenQuoteExpected, PITargetRequired, PseudoAttrNameExpected, QuoteRequiredInXMLDecl,
-	SDDeclInvalid, SpaceRequiredBeforeEncodingInXMLDecl, SpaceRequiredBeforeStandalone, SpaceRequiredInPI,
-	VersionInfoRequired, VersionNotSupported, XMLDeclUnterminated, CustomETag, PrematureEOF; // https://wiki.xmldation.com/Support/Validator/EqRequiredInAttribute
+	RootElementTypeMustMatchDoctypedecl, SDDeclInvalid, SpaceRequiredBeforeEncodingInXMLDecl,
+	SpaceRequiredBeforeStandalone, SpaceRequiredInPI,VersionInfoRequired, VersionNotSupported, 
+	XMLDeclUnterminated, CustomETag, PrematureEOF;
 
 	private final String code;
 
@@ -102,6 +104,7 @@ public enum XMLSyntaxErrorCode implements IXMLErrorCode {
 		case VersionInfoRequired:
 		case ElementPrefixUnbound:
 		case ElementUnterminated:
+		case RootElementTypeMustMatchDoctypedecl:
 			return XMLPositionUtility.selectStartTag(offset, document);
 		case EqRequiredInAttribute: {
 			String attrName = getString(arguments[1]);

--- a/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
+++ b/org.eclipse.lsp4xml/src/test/java/org/eclipse/lsp4xml/extensions/contentmodel/XMLSyntaxDiagnosticsTest.java
@@ -362,6 +362,19 @@ public class XMLSyntaxDiagnosticsTest {
 	}
 
 	@Test
+	public void testRootElementTypeMustMatchDoctypedecl() {
+		String xml =
+		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n" +
+		"<!DOCTYPE efgh [ \r\n" +
+		"<!ELEMENT abcd (#PCDATA)>\r\n" +
+		"<!ELEMENT efgh (#PCDATA)>\r\n" +
+		"]> \r\n" +
+		"<abcd/>";
+
+		testDiagnosticsFor(xml, d(5, 1, 5, 5, XMLSyntaxErrorCode.RootElementTypeMustMatchDoctypedecl));
+	}
+
+	@Test
 	public void testSDDeclInvalid() throws Exception {
 		String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"en\"?>";
 		testDiagnosticsFor(xml, d(0, 48, 0, 52, XMLSyntaxErrorCode.SDDeclInvalid));


### PR DESCRIPTION
Fixes #537

![image](https://user-images.githubusercontent.com/20326645/63461777-693ec200-c427-11e9-8de8-982333317a28.png)

This PR did not implement the code actions mentioned in the issue however.
Signed-off-by: David Kwon <dakwon@redhat.com>